### PR TITLE
Added Link to Git Diff for Github Repositories to Bridgehead Update

### DIFF
--- a/lib/update-bridgehead.sh
+++ b/lib/update-bridgehead.sh
@@ -8,10 +8,16 @@ for DIR in /etc/bridgehead $(pwd); do
   old_git_hash="$(git -C $DIR rev-parse --verify HEAD)"
   git -C $DIR fetch 2>&1
   git -C $DIR pull 2>&1
+  git -C $DIR remote -v
   new_git_hash="$(git -C $DIR rev-parse --verify HEAD)"
   git_updated="false"
   if [ "$old_git_hash" != "$new_git_hash" ]; then
-    log "INFO" "Pulled new changes from origin"
+    log "INFO" "Updated git repository in ${DIR} from commit $old_git_hash to $new_git_hash"
+    # NOTE: Link generation doesn't work on repositories placed at an self-hosted instance of bitbucket.
+    # See: https://community.atlassian.com/t5/Bitbucket-questions/BitBucket-4-14-diff-between-any-two-commits/qaq-p/632974
+    if [ "$(git -C $DIR remote get-url origin | grep "github.com")" ]; then
+      log "INFO" "You can review all changes on the repository with https://github.com/samply/bridgehead/compare/$old_git_hash...$new_git_hash"
+    fi
     git_updated="true"
   fi
 done
@@ -33,3 +39,5 @@ if [ $git_updated = "true" ] || [ $docker_updated = "true" ]; then
 fi
 log "INFO" "checking updates finished"
 exit 0
+
+# TODO: Print last commit explicit


### PR DESCRIPTION
Check for Github is necessary. Bitbucket Server doesn't support commit based diffs for whole repositories [refer to this as source](https://community.atlassian.com/t5/Bitbucket-questions/BitBucket-4-14-diff-between-any-two-commits/qaq-p/632974).
Later we could check how to generate Gitlab or Bitbucket.org diffs.