### PR TITLE
Added Environment Flag to differ between Test- and Productionsystem

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -68,3 +68,7 @@ fetchVarsFromVault() {
 ##Setting Network properties
 export HOSTIP=$(MSYS_NO_PATHCONV=1 docker run --rm --add-host=host.docker.internal:host-gateway ubuntu cat /etc/hosts | grep 'host.docker.internal' | awk '{print $1}');
 export HOST=$(hostname)
+export PRODUCTION="false";
+if [ "$(git branch --show-current)" == "main" ]; then
+	export PRODUCTION="true";
+fi


### PR DESCRIPTION
This flag is intended for usage in all docker images. It will be exposed to their environment by the bridgehead start command.