### PR TITLE
Updated Blaze from v0.17 -> v0.18

### DIFF
--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       SITE_NAME: ${SITE_NAME}
 
   blaze:
-    image: "samply/blaze:0.17"
+    image: "samply/blaze:0.18"
     container_name: bridgehead-ccp-blaze
     environment:
       BASE_URL: "http://bridgehead-ccp-blaze:8080"


### PR DESCRIPTION
This fixes the issue with incorrect specimen response. The blaze data should be persisted as volume blaze-data is configured, so no reimport necessary. 
After merge all bridgeheads should pull the update at the start of the next hour.