### PR TITLE
hotfix: Switch to old Project Name

### DIFF
--- a/bridgehead
+++ b/bridgehead
@@ -66,11 +66,13 @@ case "$ACTION" in
 		checkRequirements
 		hc_send log "Bridgehead $PROJECT startup: Requirements checked out. Now starting bridgehead ..."
 		export LDM_LOGIN=$(getLdmPassword)
-		exec $COMPOSE -p bridgehead-$PROJECT -f ./$PROJECT/docker-compose.yml $OVERRIDE up --abort-on-container-exit
+		exec $COMPOSE -f ./$PROJECT/docker-compose.yml $OVERRIDE up --abort-on-container-exit
 		;;
 	stop)
 		loadVars
-		exec $COMPOSE -p bridgehead-$PROJECT -f ./$PROJECT/docker-compose.yml $OVERRIDE down
+		# HACK: This is tempoarily to properly shut down false bridgehead instances (bridgehead-ccp instead ccp)
+		$COMPOSE -p bridgehead-$PROJECT -f ./$PROJECT/docker-compose.yml $OVERRIDE down
+		exec $COMPOSE -f ./$PROJECT/docker-compose.yml $OVERRIDE down
 		;;
 	is-running)
 		bk_is_running

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -171,7 +171,7 @@ function retry {
 
 function bk_is_running {
 	detectCompose
-	RUNNING="$($COMPOSE -p bridgehead-$PROJECT -f ./$PROJECT/docker-compose.yml $OVERRIDE ps -q)"
+	RUNNING="$($COMPOSE -p $PROJECT -f ./$PROJECT/docker-compose.yml $OVERRIDE ps -q)"
 	NUMBEROFRUNNING=$(echo "$RUNNING" | wc -l)
 	if [ $NUMBEROFRUNNING -ge 2 ]; then
 		return 0


### PR DESCRIPTION
With this, bridgeheads will switch back to the correct blaze volumes.