### PR TITLE
Update variable name to make enroll command work for BBMRI

### DIFF
--- a/bbmri/docker-compose.yml
+++ b/bbmri/docker-compose.yml
@@ -76,8 +76,8 @@ services:
     container_name: bridgehead-focus
     environment:
       API_KEY: ${FOCUS_BEAM_SECRET_SHORT}
-      BEAM_APP_ID_LONG: focus.${PROXY_ID_LONG}
-      PROXY_ID: ${PROXY_ID_LONG}
+      BEAM_APP_ID_LONG: focus.${PROXY_ID}
+      PROXY_ID: ${PROXY_ID}
       BLAZE_URL: "http://bridgehead-bbmri-blaze:8080/fhir/"
       BEAM_PROXY_URL: http://beam-proxy:8081
       RETRY_COUNT: ${FOCUS_RETRY_COUNT}
@@ -90,7 +90,7 @@ services:
     container_name: bridgehead-beam-proxy
     environment:
       BROKER_URL: ${BROKER_URL}
-      PROXY_ID: ${PROXY_ID_LONG}
+      PROXY_ID: ${PROXY_ID}
       APP_0_ID: focus
       APP_0_KEY: ${FOCUS_BEAM_SECRET_SHORT}
       PRIVKEY_FILE: /run/secrets/proxy.pem

--- a/bbmri/vars
+++ b/bbmri/vars
@@ -1,6 +1,6 @@
 BROKER_ID=broker.bbmri.samply.de
 BROKER_URL=https://${BROKER_ID}
-PROXY_ID_LONG=${SITE_ID}.${BROKER_ID}
+PROXY_ID=${SITE_ID}.${BROKER_ID}
 FOCUS_BEAM_SECRET_SHORT="$(cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 20)"
 FOCUS_RETRY_COUNT=32
 SUPPORT_EMAIL=bridgehead@helpdesk.bbmri-eric.eu


### PR DESCRIPTION
BBMRI currently uses `PROXY_ID_LONG` as an environment variable for the Beam.Proxy ID. CCP *and the bridgehead enroll* script uses ` PROXY_ID`. This PR aligns the variable names.