### PR TITLE
Remove SIGKILL for forward-proxy

### DIFF
--- a/snap/docker-compose.yml
+++ b/snap/docker-compose.yml
@@ -32,7 +32,6 @@ services:
 
   forward_proxy:
     container_name: bridgehead-forward-proxy
-    stop_signal: SIGKILL
     image: docker.verbis.dkfz.de/cache/samply/bridgehead-forward-proxy:latest
     environment:
       HTTPS_PROXY: ${HTTPS_PROXY_URL}


### PR DESCRIPTION
This is no longer required as it is now defined in the image itself, see https://github.com/samply/bridgehead-forward-proxy/pull/9