### PR TITLE
Replace deprecated openssl command

### DIFF
--- a/ccp/modules/id-management-setup.sh
+++ b/ccp/modules/id-management-setup.sh
@@ -6,7 +6,7 @@ function idManagementSetup() {
 		OVERRIDE+=" -f ./$PROJECT/modules/id-management-compose.yml"
 
 		# Auto Generate local Passwords
-		PATIENTLIST_POSTGRES_PASSWORD="$(echo \"id-management-module-db-password-salt\" | openssl rsautl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
+		PATIENTLIST_POSTGRES_PASSWORD="$(echo \"id-management-module-db-password-salt\" | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
 		IDMANAGER_LOCAL_PATIENTLIST_APIKEY="$(cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 20)"
 
 		# Transform Seeds Configuration to pass it to the Mainzelliste Container


### PR DESCRIPTION
The openssl command rsautl, used to create deterministic but secret passwords, was deprecated in openssl version 3.0. This PR changes to the new syntax.