### PR TITLE
Rely on beam-enroll message for existing key

### DIFF
--- a/bridgehead
+++ b/bridgehead
@@ -97,10 +97,6 @@ case "$ACTION" in
 		;;
 	enroll)
 		loadVars
-		if [ -e $PRIVATEKEYFILENAME ]; then
-			log ERROR "Private key already exists at $PRIVATEKEYFILENAME. Please delete first to proceed."
-			exit 1
-		fi
 		docker run --rm -ti -v /etc/bridgehead/pki:/etc/bridgehead/pki samply/beam-enroll:latest --output-file $PRIVATEKEYFILENAME --proxy-id $PROXY_ID --admin-email $SUPPORT_EMAIL
 		chmod 600 $PRIVATEKEYFILENAME
 		;;


### PR DESCRIPTION
With the new behaviour of Beam-Enroll to also display the CSR of exsisting private keys, it is preferrable to remove the "abort on existing private key" check.