### PR TITLE
Make certs work with beam-connect

### DIFF
--- a/ccp/modules/datashield-compose.yml
+++ b/ccp/modules/datashield-compose.yml
@@ -106,7 +106,7 @@ services:
 
 secrets:
   opal-cert.pem:
-    file: /etc/bridgehead/trusted-ca-certs/opal-cert.pem:ro
+    file: /etc/bridgehead/trusted-ca-certs/opal-cert.pem
   opal-key.pem:
-    file: /etc/bridgehead/trusted-ca-certs/opal-key.pem:ro
+    file: /etc/bridgehead/trusted-ca-certs/opal-key.pem
   

--- a/ccp/modules/datashield-compose.yml
+++ b/ccp/modules/datashield-compose.yml
@@ -69,7 +69,9 @@ services:
     image: datashield/rock-base:6.2-R4.2  # https://datashield.discourse.group/t/ds-aggregate-method-error/416/4
 
   beam-connect:
-    image: docker.verbis.dkfz.de/cache/samply/beam-connect:fix-connect
+    # We want to switch to this image if the changes from fix-connect are merged
+    # image: docker.verbis.dkfz.de/cache/samply/beam-connect:no-auth
+    image: samply/beam-connect:fix-connect
     container_name: bridgehead-datashield-connect
     ports:
       - 8062:8062

--- a/ccp/modules/datashield-compose.yml
+++ b/ccp/modules/datashield-compose.yml
@@ -69,9 +69,7 @@ services:
     image: datashield/rock-base:6.2-R4.2  # https://datashield.discourse.group/t/ds-aggregate-method-error/416/4
 
   beam-connect:
-    # We want to switch to this image if the changes from fix-connect are merged
-    # image: docker.verbis.dkfz.de/cache/samply/beam-connect:no-auth
-    image: samply/beam-connect:fix-connect
+    image: docker.verbis.dkfz.de/cache/samply/beam-connect:no-auth
     container_name: bridgehead-datashield-connect
     ports:
       - 8062:8062

--- a/ccp/modules/datashield-compose.yml
+++ b/ccp/modules/datashield-compose.yml
@@ -69,16 +69,19 @@ services:
     image: datashield/rock-base:6.2-R4.2  # https://datashield.discourse.group/t/ds-aggregate-method-error/416/4
 
   beam-connect:
-    image: docker.verbis.dkfz.de/cache/samply/beam-connect:develop
+    image: docker.verbis.dkfz.de/cache/samply/beam-connect:fix-connect
     container_name: bridgehead-datashield-connect
     ports:
       - 8062:8062
     environment:
       PROXY_URL: "http://beam-proxy:8081"
+      TLS_CA_CERTIFICATES_DIR: /run/secrets
       APP_ID: datashield-connect.${SITE_ID}.${BROKER_ID}
       PROXY_APIKEY: ${DATASHIELD_CONNECT_SECRET}
       DISCOVERY_URL: "./map/central.json"
       LOCAL_TARGETS_FILE: "./map/local.json"
+    secrets:
+      - opal-cert.pem
     depends_on:
       - beam-proxy
     volumes:
@@ -101,6 +104,7 @@ services:
 
 secrets:
   opal-cert.pem:
-    file: /etc/bridgehead/traefik-tls/opal-cert.pem
+    file: /etc/bridgehead/trusted-ca-certs/opal-cert.pem:ro
   opal-key.pem:
-    file: /etc/bridgehead/traefik-tls/opal-key.pem
+    file: /etc/bridgehead/trusted-ca-certs/opal-key.pem:ro
+  

--- a/ccp/modules/datashield-setup.sh
+++ b/ccp/modules/datashield-setup.sh
@@ -5,6 +5,9 @@ if [ "$ENABLE_DATASHIELD" == true ];then
   OVERRIDE+=" -f ./$PROJECT/modules/datashield-compose.yml"
 fi
 OPAL_DB_PASSWORD="$(echo \"This is a salt string to generate one consistent password for Opal. It is not required to be secret.\" | openssl rsautl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
-if [ ! -e "/etc/bridgehead/traefik-tls/opal-cert.pem" ]; then
-  openssl req -x509 -newkey rsa:4096 -nodes -keyout /etc/bridgehead/traefik-tls/opal-key.pem -out /etc/bridgehead/traefik-tls/opal-cert.pem -days 3650 -subj "/CN=$HOST"
+if [ ! -e "/etc/bridgehead/trusted-ca-certs/opal-cert.pem" ]; then
+  openssl req -x509 -newkey rsa:4096 -nodes -keyout /etc/bridgehead/trusted-ca-certs/opal-key.pem -out /etc/bridgehead/trusted-ca-certs/opal-cert.pem -days 3650 -subj "/CN=${HOST:-opal}/C=DE"
+  chmod g+r /etc/bridgehead/trusted-ca-certs/opal-key.pem
+  chown bridgehead:docker /etc/bridgehead/trusted-ca-certs/opal-key.pem
+  chown bridgehead:docker /etc/bridgehead/trusted-ca-certs/opal-cert.pem
 fi


### PR DESCRIPTION
Changes:
- Opal certs get generated and read at `/etc/bridgehead/trusted-ca-certs`
- Beam connect actually uses the cert know
- This uses beam-connect:fix-connect which is a WIP branch that will at some point be merged into no-auth which is replicated by harbor