### PR TITLE
Ensure Id Management redirects with SSL

### DIFF
--- a/ccp/modules/id-management-compose.yml
+++ b/ccp/modules/id-management-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: bridgehead-id-manager
     environment:
       TOMCAT_REVERSEPROXY_FQDN: ${HOST}
+      TOMCAT_REVERSEPROXY_SSL: "true"
       MAGICPL_SITE: ${IDMANAGEMENT_FRIENDLY_ID}
       MAGICPL_ALLOWED_ORIGINS: https://${HOST}
       MAGICPL_LOCAL_PATIENTLIST_APIKEY: ${IDMANAGER_LOCAL_PATIENTLIST_APIKEY}


### PR DESCRIPTION
Otherwise, the id-manager will always redirect to http instead of https.