### PR TITLE
Prevent creation of anonymous volumes

### DIFF
--- a/minimal/docker-compose.yml
+++ b/minimal/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       HTTPS_PROXY: ${HTTPS_PROXY_URL}
       USERNAME: ${HTTPS_PROXY_USERNAME}
       PASSWORD: ${HTTPS_PROXY_PASSWORD}
+    tmpfs:
+      - /var/log/squid
+      - /var/spool/squid
     volumes:
       - /etc/bridgehead/trusted-ca-certs:/docker/custom-certs/:ro
 


### PR DESCRIPTION
In combination with https://github.com/samply/bridgehead-forward-proxy/pull/10, this will prevent the creation of two anonymous volumes per startup for the bridgehead-forward-proxy.