### PR TITLE
Use beam-connect:develop for DNPM

### DIFF
--- a/bbmri/modules/dnpm-compose.yml
+++ b/bbmri/modules/dnpm-compose.yml
@@ -22,7 +22,7 @@ services:
 
   dnpm-beam-connect:
     depends_on: [ dnpm-beam-proxy ]
-    image: docker.verbis.dkfz.de/cache/samply/beam-connect:dnpm
+    image: docker.verbis.dkfz.de/cache/samply/beam-connect:develop
     container_name: bridgehead-dnpm-beam-connect
     environment:
       PROXY_URL: http://dnpm-beam-proxy:8081
@@ -34,6 +34,7 @@ services:
       HTTPS_PROXY: http://forward_proxy:3128
       NO_PROXY: dnpm-beam-proxy,dnpm-backend
       RUST_LOG: ${RUST_LOG:-info}
+      NO_AUTH: true
     volumes:
       - /etc/bridgehead/dnpm/local_targets.json:/conf/connect_targets.json:ro
       - /etc/bridgehead/dnpm/central_targets.json:/conf/central_targets.json:ro

--- a/ccp/modules/dnpm-compose.yml
+++ b/ccp/modules/dnpm-compose.yml
@@ -6,7 +6,7 @@ services:
       APP_dnpm-connect_KEY: ${DNPM_BEAM_SECRET_SHORT}
   dnpm-beam-connect:
     depends_on: [ beam-proxy ]
-    image: docker.verbis.dkfz.de/cache/samply/beam-connect:dnpm
+    image: docker.verbis.dkfz.de/cache/samply/beam-connect:develop
     container_name: bridgehead-dnpm-beam-connect
     environment:
       PROXY_URL: http://beam-proxy:8081
@@ -18,6 +18,7 @@ services:
       HTTPS_PROXY: "http://forward_proxy:3128"
       NO_PROXY: beam-proxy,dnpm-backend
       RUST_LOG: ${RUST_LOG:-info}
+      NO_AUTH: true
     volumes:
       - /etc/bridgehead/dnpm/local_targets.json:/conf/connect_targets.json:ro
       - /etc/bridgehead/dnpm/central_targets.json:/conf/central_targets.json:ro

--- a/minimal/modules/dnpm-compose.yml
+++ b/minimal/modules/dnpm-compose.yml
@@ -22,7 +22,7 @@ services:
 
   dnpm-beam-connect:
     depends_on: [ dnpm-beam-proxy ]
-    image: docker.verbis.dkfz.de/cache/samply/beam-connect:dnpm
+    image: docker.verbis.dkfz.de/cache/samply/beam-connect:develop
     container_name: bridgehead-dnpm-beam-connect
     environment:
       PROXY_URL: http://dnpm-beam-proxy:8081
@@ -34,6 +34,7 @@ services:
       HTTPS_PROXY: http://forward_proxy:3128
       NO_PROXY: dnpm-beam-proxy,dnpm-backend
       RUST_LOG: ${RUST_LOG:-info}
+      NO_AUTH: true
     volumes:
       - /etc/bridgehead/dnpm/local_targets.json:/conf/connect_targets.json:ro
       - /etc/bridgehead/dnpm/central_targets.json:/conf/central_targets.json:ro


### PR DESCRIPTION
All required features for DNPM have been integrated in Beam-Connect's `develop` branch, so that no special tag is required anymore.