### PR TITLE
Fix dnpm connect env, from bool to string

### DIFF
--- a/bbmri/modules/dnpm-compose.yml
+++ b/bbmri/modules/dnpm-compose.yml
@@ -34,7 +34,7 @@ services:
       HTTPS_PROXY: http://forward_proxy:3128
       NO_PROXY: dnpm-beam-proxy,dnpm-backend
       RUST_LOG: ${RUST_LOG:-info}
-      NO_AUTH: true
+      NO_AUTH: "true"
     volumes:
       - /etc/bridgehead/dnpm/local_targets.json:/conf/connect_targets.json:ro
       - /etc/bridgehead/dnpm/central_targets.json:/conf/central_targets.json:ro

--- a/ccp/modules/dnpm-compose.yml
+++ b/ccp/modules/dnpm-compose.yml
@@ -18,7 +18,7 @@ services:
       HTTPS_PROXY: "http://forward_proxy:3128"
       NO_PROXY: beam-proxy,dnpm-backend
       RUST_LOG: ${RUST_LOG:-info}
-      NO_AUTH: true
+      NO_AUTH: "true"
     volumes:
       - /etc/bridgehead/dnpm/local_targets.json:/conf/connect_targets.json:ro
       - /etc/bridgehead/dnpm/central_targets.json:/conf/central_targets.json:ro

--- a/minimal/modules/dnpm-compose.yml
+++ b/minimal/modules/dnpm-compose.yml
@@ -34,7 +34,7 @@ services:
       HTTPS_PROXY: http://forward_proxy:3128
       NO_PROXY: dnpm-beam-proxy,dnpm-backend
       RUST_LOG: ${RUST_LOG:-info}
-      NO_AUTH: true
+      NO_AUTH: "true"
     volumes:
       - /etc/bridgehead/dnpm/local_targets.json:/conf/connect_targets.json:ro
       - /etc/bridgehead/dnpm/central_targets.json:/conf/central_targets.json:ro


### PR DESCRIPTION
Apparently, for some combinations of docker-compose and bash enforcing a string value in the `NO_AUTH` parameter is necessary for successful startup of beam-connect.