### PR TITLE
Fix script for the creation of persistent keys

### DIFF
--- a/bbmri/modules/dnpm-setup.sh
+++ b/bbmri/modules/dnpm-setup.sh
@@ -5,7 +5,7 @@ if [ -n "${ENABLE_DNPM}" ]; then
 	OVERRIDE+=" -f ./$PROJECT/modules/dnpm-compose.yml"
 
 	# Set variables required for Beam-Connect
-	DNPM_APPLICATION_SECRET="$(echo \"This is a salt string to generate one consistent password for DNPM. It is not required to be secret.\" | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
+	DNPM_APPLICATION_SECRET="$(echo \"This is a salt string to generate one consistent password for DNPM. It is not required to be secret.\" | sha1sum | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
 	DNPM_BEAM_SECRET_SHORT="$(cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 20)"
 	DNPM_BROKER_ID="broker.ccp-it.dktk.dkfz.de"
 	DNPM_BROKER_URL="https://${DNPM_BROKER_ID}"

--- a/ccp/modules/dnpm-setup.sh
+++ b/ccp/modules/dnpm-setup.sh
@@ -5,6 +5,6 @@ if [ -n "${ENABLE_DNPM}" ]; then
 	OVERRIDE+=" -f ./$PROJECT/modules/dnpm-compose.yml"
 
 	# Set variables required for Beam-Connect
-	DNPM_APPLICATION_SECRET="$(echo \"This is a salt string to generate one consistent password for DNPM. It is not required to be secret.\" | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
+	DNPM_APPLICATION_SECRET="$(echo \"This is a salt string to generate one consistent password for DNPM. It is not required to be secret.\" | sha1sum | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
 	DNPM_BEAM_SECRET_SHORT="$(cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 20)"
 fi

--- a/ccp/modules/id-management-setup.sh
+++ b/ccp/modules/id-management-setup.sh
@@ -6,7 +6,7 @@ function idManagementSetup() {
 		OVERRIDE+=" -f ./$PROJECT/modules/id-management-compose.yml"
 
 		# Auto Generate local Passwords
-		PATIENTLIST_POSTGRES_PASSWORD="$(echo \"id-management-module-db-password-salt\" | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
+		PATIENTLIST_POSTGRES_PASSWORD="$(echo \"id-management-module-db-password-salt\" | sha1sum | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
 		IDMANAGER_LOCAL_PATIENTLIST_APIKEY="$(cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 20)"
 
 		# Transform Seeds Configuration to pass it to the Mainzelliste Container

--- a/minimal/modules/dnpm-setup.sh
+++ b/minimal/modules/dnpm-setup.sh
@@ -5,7 +5,7 @@ if [ -n "${ENABLE_DNPM}" ]; then
 	OVERRIDE+=" -f ./$PROJECT/modules/dnpm-compose.yml"
 
 	# Set variables required for Beam-Connect
-	DNPM_APPLICATION_SECRET="$(echo \"This is a salt string to generate one consistent password for DNPM. It is not required to be secret.\" | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
+	DNPM_APPLICATION_SECRET="$(echo \"This is a salt string to generate one consistent password for DNPM. It is not required to be secret.\" | sha1sum | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
 	DNPM_BEAM_SECRET_SHORT="$(cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 20)"
 	DNPM_BROKER_ID="broker.ccp-it.dktk.dkfz.de"
 	DNPM_BROKER_URL="https://${DNPM_BROKER_ID}"


### PR DESCRIPTION
The creation of the permanent keys in the bridgehead installer was broken, as openssl expects the input to be a (sha1 or md5) hash. This is fixed now. 

Note: This PR breaks the keys of existing bridgehead installations. Only merge after creating a migration plan.