### PR TITLE
git requires http proxy config even vor https connections

### DIFF
--- a/lib/update-bridgehead.sh
+++ b/lib/update-bridgehead.sh
@@ -55,7 +55,7 @@ for DIR in /etc/bridgehead $(pwd); do
     OUT=$(retry 5 git -C $DIR fetch 2>&1 && retry 5 git -C $DIR pull 2>&1)
   else
     log "INFO" "Git is using proxy ${HTTPS_PROXY_URL} from ${CONFFILE}"
-    OUT=$(retry 5 git -c https.proxy=$HTTPS_PROXY_FULL_URL -C $DIR fetch 2>&1 && retry 5 git -c https.proxy=$HTTPS_PROXY_FULL_URL -C $DIR pull 2>&1)
+    OUT=$(retry 5 git -c http.proxy=$HTTPS_PROXY_FULL_URL -c https.proxy=$HTTPS_PROXY_FULL_URL -C $DIR fetch 2>&1 && retry 5 git -c http.proxy=$HTTPS_PROXY_FULL_URL -c https.proxy=$HTTPS_PROXY_FULL_URL -C $DIR pull 2>&1)
   fi
   if [ $? -ne 0 ]; then
     report_error log "Unable to update git $DIR: $OUT"


### PR DESCRIPTION
Even if the repository URL uses HTTPS, git uses the http.proxy configuration if the *proxy* is reachable via HTTP.