### PR TITLE
Enable obfuscation for ccp queries

### DIFF
--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       BLAZE_URL: "http://bridgehead-ccp-blaze:8080/fhir/"
       BEAM_PROXY_URL: http://beam-proxy:8081
       RETRY_COUNT: ${FOCUS_RETRY_COUNT}
-      OBFUSCATE: "no"
+      EPSILON: 0.28
     depends_on:
       - "beam-proxy"
       - "blaze"


### PR DESCRIPTION
Enable statistical obfuscation for CCP query results. Chosen Parameters:

* Epsilon = 0.28
* Sensitivity Patients/Specimen/Diagnosis/Procedures/Medication Statements= 1/20/3/1.7/2.1
* Don't obfuscate real zeros
* Display 10 for 0 < count < 10
* Round to the next 10s

Required for merging:

- [x] Handle DKTK MeasureReport in Focus
- [x] Test in Mannheim
- [x] Go-ahead from CCP office