### PR TITLE
Add nngm module to minimal project

### DIFF
--- a/minimal/modules/nngm-compose.yml
+++ b/minimal/modules/nngm-compose.yml
@@ -1,0 +1,29 @@
+version: "3.7"
+volumes:
+  nngm-rest:
+
+services:
+  connector:
+    container_name: bridgehead-connector
+    image: docker.verbis.dkfz.de/ccp/nngm-rest:main
+    environment:
+      CTS_MAGICPL_API_KEY: ${NNGM_MAGICPL_APIKEY}
+      CTS_API_KEY: ${NNGM_CTS_APIKEY}
+      CRYPT_KEY: ${NNGM_CRYPTKEY}
+      #CTS_MAGICPL_SITE: ${SITE_ID}TODO
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.connector.rule=PathPrefix(`/nngm-connector`)"
+      - "traefik.http.middlewares.connector_strip.stripprefix.prefixes=/nngm-connector"
+      - "traefik.http.services.connector.loadbalancer.server.port=8080"
+      - "traefik.http.routers.connector.tls=true"
+      - "traefik.http.routers.connector.middlewares=connector_strip,auth-nngm"
+    volumes:
+      - nngm-rest:/var/log
+
+  traefik:
+    labels:
+      - "traefik.http.middlewares.auth-nngm.basicauth.users=${NNGM_AUTH}"
+
+

--- a/minimal/modules/nngm-setup.sh
+++ b/minimal/modules/nngm-setup.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-function nngmSetup() {
-	if [ -n "$NNGM_CTS_APIKEY" ]; then
-		log INFO "nNGM setup detected -- will start nNGM Connector."
-		OVERRIDE+=" -f ./$PROJECT/modules/nngm-compose.yml"
-	fi
-	}
+if [ -n "$NNGM_CTS_APIKEY" ]; then
+  log INFO "nNGM setup detected -- will start nNGM Connector."
+  OVERRIDE+=" -f ./$PROJECT/modules/nngm-compose.yml"
+fi

--- a/minimal/modules/nngm-setup.sh
+++ b/minimal/modules/nngm-setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function nngmSetup() {
+	if [ -n "$NNGM_CTS_APIKEY" ]; then
+		log INFO "nNGM setup detected -- will start nNGM Connector."
+		OVERRIDE+=" -f ./$PROJECT/modules/nngm-compose.yml"
+	fi
+	}


### PR DESCRIPTION
For running a combined DNPM and nNGM bridgehead it is required to use the nngm module out of the minimal project.