### PR TITLE
Fix image updates for image names with vars

### DIFF
--- a/lib/update-bridgehead.sh
+++ b/lib/update-bridgehead.sh
@@ -86,7 +86,7 @@ done
 # Check docker updates
 log "INFO" "Checking for updates to running docker images ..."
 docker_updated="false"
-for IMAGE in $(cat $PROJECT/docker-compose.yml ${OVERRIDE//-f/} minimal/docker-compose.yml | grep -v "^#" | grep "image:" | sed -e 's_^.*image: \(.*\).*$_\1_g; s_\"__g'); do
+for IMAGE in $($COMPOSE -f ./minimal/docker-compose.yml -f ./$PROJECT/docker-compose.yml $OVERRIDE config --images); do
   log "INFO" "Checking for Updates of Image: $IMAGE"
   if docker pull $IMAGE | grep "Downloaded newer image"; then
     CHANGE="Image $IMAGE updated."


### PR DESCRIPTION
This now uses `docker compose config --images` to gather all used images instead of trying to find the image names with a regex.
This has the added benefit of removing comments and interpolating env vars for us.
This fixes the focus updates not getting pulled since #142 because they get their tag from env since that version.
The only concern here is that `docker-compose config` and `docker compose config` are not present on the docker versions at some sites.