### PR TITLE
Optimize memory usage of Blaze

### DIFF
--- a/bbmri/docker-compose.yml
+++ b/bbmri/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       BASE_URL: "http://bridgehead-bbmri-blaze:8080"
       JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP:-4096}m"
+      DB_RESOURCE_CACHE_SIZE: ${BLAZE_RESOURCE_CACHE_CAP:-2500000}
       DB_BLOCK_CACHE_SIZE: $BLAZE_MEMORY_CAP
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     volumes:

--- a/bbmri/docker-compose.yml
+++ b/bbmri/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     container_name: bridgehead-bbmri-blaze
     environment:
       BASE_URL: "http://bridgehead-bbmri-blaze:8080"
-      JAVA_TOOL_OPTIONS: "-Xmx4g"
-      LOG_LEVEL: "debug"
+      JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP}m"
+      DB_BLOCK_CACHE_SIZE: $BLAZE_MEMORY_CAP
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     volumes:
       - "blaze-data:/app/data"

--- a/bbmri/docker-compose.yml
+++ b/bbmri/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: bridgehead-bbmri-blaze
     environment:
       BASE_URL: "http://bridgehead-bbmri-blaze:8080"
-      JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP}m"
+      JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP:-4096}m"
       DB_BLOCK_CACHE_SIZE: $BLAZE_MEMORY_CAP
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     volumes:

--- a/bridgehead
+++ b/bridgehead
@@ -50,6 +50,7 @@ loadVars() {
 		source /etc/bridgehead/$PROJECT.local.conf || fail_and_report 1 "Found /etc/bridgehead/$PROJECT.local.conf but failed to import"
 	fi
 	fetchVarsFromVaultByFile /etc/bridgehead/$PROJECT.conf || fail_and_report 1 "Unable to fetchVarsFromVaultByFile"
+	setBlazeMemoryCap
 	[ -e ./$PROJECT/vars ] && source ./$PROJECT/vars
 	set +a
 

--- a/bridgehead
+++ b/bridgehead
@@ -50,7 +50,7 @@ loadVars() {
 		source /etc/bridgehead/$PROJECT.local.conf || fail_and_report 1 "Found /etc/bridgehead/$PROJECT.local.conf but failed to import"
 	fi
 	fetchVarsFromVaultByFile /etc/bridgehead/$PROJECT.conf || fail_and_report 1 "Unable to fetchVarsFromVaultByFile"
-	setBlazeMemoryCap
+	optimizeBlazeMemoryUsage
 	[ -e ./$PROJECT/vars ] && source ./$PROJECT/vars
 	set +a
 

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     container_name: bridgehead-ccp-blaze
     environment:
       BASE_URL: "http://bridgehead-ccp-blaze:8080"
-      JAVA_TOOL_OPTIONS: "-Xmx4g"
+      JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP}m"
+      DB_BLOCK_CACHE_SIZE: $BLAZE_MEMORY_CAP
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     volumes:
       - "blaze-data:/app/data"

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       BASE_URL: "http://bridgehead-ccp-blaze:8080"
       JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP:-4096}m"
+      DB_RESOURCE_CACHE_SIZE: ${BLAZE_RESOURCE_CACHE_CAP:-2500000}
       DB_BLOCK_CACHE_SIZE: $BLAZE_MEMORY_CAP
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     volumes:

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: bridgehead-ccp-blaze
     environment:
       BASE_URL: "http://bridgehead-ccp-blaze:8080"
-      JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP}m"
+      JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP:-4096}m"
       DB_BLOCK_CACHE_SIZE: $BLAZE_MEMORY_CAP
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     volumes:

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -155,6 +155,16 @@ setHostname() {
 	fi
 }
 
+# blaze memory cap should be approximately a quarter of the system memory
+# the memory cap will be applied to both the java heap size and db clock cache
+setBlazeMemoryCap() {
+	if [ -z "$BLAZE_MEMORY_CAP" ]; then
+	   system_memory=$(grep MemTotal /proc/meminfo | grep -Po '\d+');
+	   system_memory_in_mb=$(("$system_memory"/1024));
+	   export BLAZE_MEMORY_CAP=$(("$system_memory_in_mb"/4));
+	fi
+}
+
 # Takes 1) The Backup Directory Path 2) The name of the Service to be backuped
 # Creates 3 Backups: 1) For the past seven days 2) For the current month and 3) for each calendar week
 createEncryptedPostgresBackup(){

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -159,8 +159,7 @@ setHostname() {
 # the memory cap will be applied to both the java heap size and db clock cache
 setBlazeMemoryCap() {
 	if [ -z "$BLAZE_MEMORY_CAP" ]; then
-	   system_memory=$(grep MemTotal /proc/meminfo | grep -Po '\d+');
-	   system_memory_in_mb=$(("$system_memory"/1024));
+	   system_memory_in_mb=$(free -m | grep 'Mem:' | awk '{print $2}');
 	   export BLAZE_MEMORY_CAP=$(("$system_memory_in_mb"/4));
 	fi
 }


### PR DESCRIPTION
This will adjust the memory used by blaze on the different servers. The bridgehead start script reads the available memory from /proc/meminfo and calculates the amount to give to blaze in Megabyte. With this, blaze should receive approxymately one half of the RAM available to the systems, as one quarter is used for each, the java heap size and the db cache.
I tested it locally in wsl, where the amount used by blaze was reduced from 4G to 1951m. It would be good if someone could test it on a server.
- [x] test in local environment (wsl)
- [x] test on server 