### PR TITLE
Add DNPM_NO_PROXY configuration option

### DIFF
--- a/ccp/modules/dnpm-compose.yml
+++ b/ccp/modules/dnpm-compose.yml
@@ -16,7 +16,7 @@ services:
       LOCAL_TARGETS_FILE: "./conf/connect_targets.json"
       HTTP_PROXY: "http://forward_proxy:3128"
       HTTPS_PROXY: "http://forward_proxy:3128"
-      NO_PROXY: beam-proxy,dnpm-backend,host.docker.internal
+      NO_PROXY: beam-proxy,dnpm-backend,host.docker.internal${DNPM_ADDITIONAL_NO_PROXY}
       RUST_LOG: ${RUST_LOG:-info}
       NO_AUTH: "true"
     extra_hosts:

--- a/ccp/modules/dnpm-setup.sh
+++ b/ccp/modules/dnpm-setup.sh
@@ -6,4 +6,10 @@ if [ -n "${ENABLE_DNPM}" ]; then
 
 	# Set variables required for Beam-Connect
 	DNPM_BEAM_SECRET_SHORT="$(cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 20)"
+	# If the DNPM_NO_PROXY variable is set, prefix it with a comma (as it gets added to a comma separated list)
+	if [ -n "${DNPM_NO_PROXY}" ]; then
+		DNPM_ADDITIONAL_NO_PROXY=",${DNPM_NO_PROXY}"
+	else
+		DNPM_ADDITIONAL_NO_PROXY=""
+	fi
 fi

--- a/minimal/modules/dnpm-compose.yml
+++ b/minimal/modules/dnpm-compose.yml
@@ -32,7 +32,7 @@ services:
       LOCAL_TARGETS_FILE: "./conf/connect_targets.json"
       HTTP_PROXY: http://forward_proxy:3128
       HTTPS_PROXY: http://forward_proxy:3128
-      NO_PROXY: dnpm-beam-proxy,dnpm-backend, host.docker.internal
+      NO_PROXY: dnpm-beam-proxy,dnpm-backend, host.docker.internal${DNPM_ADDITIONAL_NO_PROXY}
       RUST_LOG: ${RUST_LOG:-info}
       NO_AUTH: "true"
     extra_hosts:

--- a/minimal/modules/dnpm-setup.sh
+++ b/minimal/modules/dnpm-setup.sh
@@ -13,4 +13,10 @@ if [ -n "${ENABLE_DNPM}" ]; then
 		log DEBUG "No Broker for clock check set; using $DNPM_BROKER_URL"
 	fi
 	DNPM_PROXY_ID="${SITE_ID}.${DNPM_BROKER_ID}"
+	# If the DNPM_NO_PROXY variable is set, prefix it with a comma (as it gets added to a comma separated list)
+	if [ -n "${DNPM_NO_PROXY}" ]; then
+		DNPM_ADDITIONAL_NO_PROXY=",${DNPM_NO_PROXY}"
+	else
+		DNPM_ADDITIONAL_NO_PROXY=""
+	fi
 fi


### PR DESCRIPTION
Some sites need to add additional no_proxy targets to the dnpm-beam-connect service.
This PR introduces an optional `DNPM_NO_PROXY` config variable, which, if set, adds the string (with an prepended comma) to the already existing dnpm-beam-connect no_proxy environment.