### PR TITLE
Create env to control dnpm synthetic data generation

### DIFF
--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: bridgehead-dnpm-backend
     environment:
       - ZPM_SITE=${ZPM_SITE}
+      - N_RANDOM_FILES=${DNPM_SYNTH_NUM}
     volumes:
       - /etc/bridgehead/dnpm:/bwhc_config:ro
       - ${DNPM_DATA_DIR}:/bwhc_data

--- a/ccp/modules/dnpm-node-setup.sh
+++ b/ccp/modules/dnpm-node-setup.sh
@@ -14,14 +14,15 @@ if [ -n "${ENABLE_DNPM_NODE}" ]; then
 		log ERROR "Mandatory variable DNPM_DATA_DIR not defined!"
 		exit 1
 	fi
-			if grep -q 'traefik.http.routers.landing.rule=PathPrefix(`/landing`)' /srv/docker/bridgehead/minimal/docker-compose.override.yml 2>/dev/null; then
-				echo "Override of landing page url already in place"
-			else
-				echo "Adding override of landing page url"
-				if [ -f /srv/docker/bridgehead/minimal/docker-compose.override.yml ]; then
-					echo -e '  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
-				else
-					echo -e 'version: "3.7"\nservices:\n  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
-				fi
-			fi
+	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:-0}
+	if grep -q 'traefik.http.routers.landing.rule=PathPrefix(`/landing`)' /srv/docker/bridgehead/minimal/docker-compose.override.yml 2>/dev/null; then
+		echo "Override of landing page url already in place"
+	else
+		echo "Adding override of landing page url"
+		if [ -f /srv/docker/bridgehead/minimal/docker-compose.override.yml ]; then
+			echo -e '  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
+		else
+			echo -e 'version: "3.7"\nservices:\n  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
+		fi
+	fi
 fi

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: bridgehead-dnpm-backend
     environment:
       - ZPM_SITE=${ZPM_SITE}
+      - N_RANDOM_FILES=${DNPM_SYNTH_NUM}
     volumes:
       - /etc/bridgehead/dnpm:/bwhc_config:ro
       - ${DNPM_DATA_DIR}:/bwhc_data

--- a/minimal/modules/dnpm-node-setup.sh
+++ b/minimal/modules/dnpm-node-setup.sh
@@ -14,14 +14,15 @@ if [ -n "${ENABLE_DNPM_NODE}" ]; then
 		log ERROR "Mandatory variable DNPM_DATA_DIR not defined!"
 		exit 1
 	fi
-			if grep -q 'traefik.http.routers.landing.rule=PathPrefix(`/landing`)' /srv/docker/bridgehead/minimal/docker-compose.override.yml 2>/dev/null; then
-				echo "Override of landing page url already in place"
-			else
-				echo "Adding override of landing page url"
-				if [ -f /srv/docker/bridgehead/minimal/docker-compose.override.yml ]; then
-					echo -e '  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
-				else
-					echo -e 'version: "3.7"\nservices:\n  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
-				fi
-			fi
+	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:-0}
+	if grep -q 'traefik.http.routers.landing.rule=PathPrefix(`/landing`)' /srv/docker/bridgehead/minimal/docker-compose.override.yml 2>/dev/null; then
+		echo "Override of landing page url already in place"
+	else
+		echo "Adding override of landing page url"
+		if [ -f /srv/docker/bridgehead/minimal/docker-compose.override.yml ]; then
+			echo -e '  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
+		else
+			echo -e 'version: "3.7"\nservices:\n  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
+		fi
+	fi
 fi


### PR DESCRIPTION
Using the `DNPM_SYNTH_NUM` environment variable the number of rendomly generated synthetic data in the dnpm_backend can be controlled. If not present or empty, it defaults to 0 generated random entries.

I added some formatting change to the setup.sh files, which were not in splittable git hunks, sorry :(