### PR TITLE
Updated ccp focus to 0.4.1

### DIFF
--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "traefik.http.routers.blaze_ccp.tls=true"
 
   focus:
-    image: docker.verbis.dkfz.de/cache/samply/focus:0.4.0
+    image: docker.verbis.dkfz.de/cache/samply/focus:0.4.1
     container_name: bridgehead-focus
     environment:
       API_KEY: ${FOCUS_BEAM_SECRET_SHORT}


### PR DESCRIPTION
Updates the ccp focus to version 0.4.1. This does obfuscate the histology counting. 