### PR TITLE
fix: Make math work on bash 4.2

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -164,7 +164,7 @@ setHostname() {
 optimizeBlazeMemoryUsage() {
 	if [ -z "$BLAZE_MEMORY_CAP" ]; then
 	   system_memory_in_mb=$(LC_ALL=C free -m | grep 'Mem:' | awk '{print $2}');
-	   export BLAZE_MEMORY_CAP=$(("$system_memory_in_mb"/4));
+	   export BLAZE_MEMORY_CAP=$(($system_memory_in_mb/4));
 	fi
 	if [ -z "$BLAZE_RESOURCE_CACHE_CAP" ]; then
 		available_system_memory_chuncks=$((BLAZE_MEMORY_CAP / 1000))


### PR DESCRIPTION
Bash 4.2 is used by CentOS and other Redhead based distros I think. The main branch did not work on serv-05 because of this.
You can try this out with docker:
```bash
docker run -it bash
echo $(("12"/4)) # Works
exit
docker run -it bash:4.2
echo $(("12"/4)) # Does not work
```