### PR TITLE
fix: Kill stale secret-sync instances

### DIFF
--- a/bridgehead
+++ b/bridgehead
@@ -96,6 +96,8 @@ case "$ACTION" in
 		;;
 	stop)
 		loadVars
+		# Kill stale secret-sync instances if present
+		docker kill $(docker ps -q --filter ancestor=docker.verbis.dkfz.de/cache/samply/secret-sync-local) 2>/dev/null || true
 		# HACK: This is temporarily to properly shut down false bridgehead instances (bridgehead-ccp instead ccp)
 		$COMPOSE -p bridgehead-$PROJECT -f ./minimal/docker-compose.yml -f ./$PROJECT/docker-compose.yml $OVERRIDE down
 		exec $COMPOSE -p $PROJECT -f ./minimal/docker-compose.yml -f ./$PROJECT/docker-compose.yml $OVERRIDE down


### PR DESCRIPTION
Still not quite sure as to why they got stale.
Never the less this will make sure they get killed if active.