### PR TITLE
Ensure Mainzelliste returns SSL in Responses

### DIFF
--- a/ccp/modules/id-management-compose.yml
+++ b/ccp/modules/id-management-compose.yml
@@ -29,6 +29,7 @@ services:
     container_name: bridgehead-patientlist
     environment:
       - TOMCAT_REVERSEPROXY_FQDN=${HOST}
+      - TOMCAT_REVERSEPROXY_SSL=true
       - ML_SITE=${IDMANAGEMENT_FRIENDLY_ID}
       - ML_DB_PASS=${PATIENTLIST_POSTGRES_PASSWORD}
       - ML_API_KEY=${IDMANAGER_LOCAL_PATIENTLIST_APIKEY}


### PR DESCRIPTION
Before this PR, the Mainzelliste would always respond with http instead of https then referring to it self in urls. 