### PR TITLE
feat: Add logs command for journalctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ You can either do this in a browser or with curl. If you visit the URL in the br
 curl -k https://localhost
 ```
 
-If you get errors when you do this, you can inspect the logs of your landing page container in order to determine what is going wrong. To do this you can use `./bridgehead docker-logs <Project> landing -f` to follow the logs of the container. This transaltes to a docker compose logs command meaning all the ususal docker logs flags work.
+Should the landing page not show anything, you can inspect the logs of the containers to determine what is going wrong. To do this you can use `./bridgehead docker-logs <Project> -f` to follow the logs of the container. This transaltes to a docker compose logs command meaning all the ususal docker logs flags work.
 
 If you have chosen to take part in our monitoring program (by setting the ```MONITOR_APIKEY``` variable in the configuration), you will be informed by email when problems are detected in your Bridgehead.
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ sudo systemctl [enable|disable] bridgehead@<PROJECT>.service
 After starting the Bridgehead, you can watch the initialization process with the following command:
 
 ```shell
-journalctl -u bridgehead@bbmri -f
+./bridghead logs <project> -f
 ```
 
 if this exits with something similar to the following:
@@ -220,8 +220,9 @@ docker ps
 There should be 6 - 10 Docker proceses. If there are fewer, then you know that something has gone wrong. To see what is going on, run:
 
 ```shell
-journalctl -u bridgehead@bbmri -f
+./bridghead logs <Project> -f
 ```
+This translates to a journalctl command so all the regular journalctl flags can be used.
 
 Once the Bridgehead has passed these checks, take a look at the landing page:
 
@@ -235,7 +236,7 @@ You can either do this in a browser or with curl. If you visit the URL in the br
 curl -k https://localhost
 ```
 
-If you get errors when you do this, you need to use ```docker logs``` to examine your landing page container in order to determine what is going wrong.
+If you get errors when you do this, you can inspect the logs of your landing page container in order to determine what is going wrong. To do this you can use `./bridgehead docker-logs <Project> landing -f` to follow the logs of the container. This transaltes to a docker compose logs command meaning all the ususal docker logs flags work.
 
 If you have chosen to take part in our monitoring program (by setting the ```MONITOR_APIKEY``` variable in the configuration), you will be informed by email when problems are detected in your Bridgehead.
 

--- a/bridgehead
+++ b/bridgehead
@@ -109,6 +109,11 @@ case "$ACTION" in
 	logs)
 		loadVars
 		shift 2
+		exec journalctl -u bridgehead@$PROJECT -u bridgehead-update@$PROJECT -a $@
+		;;
+	docker-logs)
+		loadVars
+		shift 2
 		exec $COMPOSE -p $PROJECT -f ./minimal/docker-compose.yml -f ./$PROJECT/docker-compose.yml $OVERRIDE logs -f $@
 		;;
 	update)

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -53,7 +53,7 @@ checkOwner(){
 }
 
 printUsage() {
-	echo "Usage: bridgehead start|stop|logs|is-running|update|install|uninstall|adduser|enroll PROJECTNAME"
+	echo "Usage: bridgehead start|stop|logs|docker-logs|is-running|update|install|uninstall|adduser|enroll PROJECTNAME"
 	echo "PROJECTNAME should be one of ccp|bbmri"
 }
 


### PR DESCRIPTION
I added `-a` as a default option for journalctl as it preserves the colors and fixes an issue where docker logs would only show up as `[blob data x kb]`. I dont think it has any downside