### PR TITLE
fix: set blaze to version 0.28

### DIFF
--- a/bbmri/docker-compose.yml
+++ b/bbmri/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.7"
 
 services:
   blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:latest
+    image: docker.verbis.dkfz.de/cache/samply/blaze:0.28
     container_name: bridgehead-bbmri-blaze
     environment:
       BASE_URL: "http://bridgehead-bbmri-blaze:8080"

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.27
+    image: docker.verbis.dkfz.de/cache/samply/blaze:0.28
     container_name: bridgehead-ccp-blaze
     environment:
       BASE_URL: "http://bridgehead-ccp-blaze:8080"


### PR DESCRIPTION
The 0.28 release is not downgradeable, therefore switching again to 0.28