### PR TITLE
fix: Fix traefik label for oauth2 redirect

### DIFF
--- a/ccp/modules/datashield-compose.yml
+++ b/ccp/modules/datashield-compose.yml
@@ -151,7 +151,7 @@ services:
       --pass-access-token=false
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.oauth2_proxy.rule=Host(`${HOST}`) && PathPrefix(`/oauth2`, `/oauth2/callback`)"
+      - "traefik.http.routers.oauth2_proxy.rule=Host(`${HOST}`) && PathPrefix(`/oauth2`)"
       - "traefik.http.services.oauth2_proxy.loadbalancer.server.port=4180"
       - "traefik.http.routers.oauth2_proxy.tls=true"
     environment:


### PR DESCRIPTION
The `PathPrefix` filter was never intended for 2 args I think and it seems it has become a hard error in a recent traefik version rendering the rout unavailable.