### PR TITLE
Switch ID-Management to Keycloak from Samply.Auth

### DIFF
--- a/ccp/modules/id-management-compose.yml
+++ b/ccp/modules/id-management-compose.yml
@@ -14,15 +14,15 @@ services:
       MAGICPL_CONNECTOR_APIKEY: ${IDMANAGER_READ_APIKEY}
       MAGICPL_CENTRAL_PATIENTLIST_APIKEY: ${IDMANAGER_CENTRAL_PATIENTLIST_APIKEY}
       MAGICPL_CONTROLNUMBERGENERATOR_APIKEY: ${IDMANAGER_CONTROLNUMBERGENERATOR_APIKEY}
-      MAGICPL_OIDC_CLIENT_ID: ${IDMANAGER_AUTH_CLIENT_ID}
-      MAGICPL_OIDC_CLIENT_SECRET: ${IDMANAGER_AUTH_CLIENT_SECRET}
     depends_on:
       - patientlist
+      - traefik-forward-auth
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.id-manager.rule=PathPrefix(`/id-manager`)"
       - "traefik.http.services.id-manager.loadbalancer.server.port=8080"
       - "traefik.http.routers.id-manager.tls=true"
+      - "traefik.http.routers.id-manager.middlewares=traefik-forward-auth-idm"
 
   patientlist:
     image: docker.verbis.dkfz.de/bridgehead/mainzelliste
@@ -55,6 +55,42 @@ services:
       - "patientlist-db-data:/var/lib/postgresql/data"
       # NOTE: Add backups here. This is only imported if /var/lib/bridgehead/data/patientlist/ is empty!!!
       - "/tmp/bridgehead/patientlist/:/docker-entrypoint-initdb.d/"
+
+  traefik-forward-auth:
+    image: docker.verbis.dkfz.de/cache/oauth2-proxy/oauth2-proxy:v7.6.0
+    environment:
+      - http_proxy=http://forward_proxy:3128
+      - https_proxy=http://forward_proxy:3128
+      - OAUTH2_PROXY_PROVIDER=oidc
+      - OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true
+      - OAUTH2_PROXY_OIDC_ISSUER_URL=https://login.verbis.dkfz.de/realms/master
+      - OAUTH2_PROXY_CLIENT_ID=bridgehead-${SITE_ID}
+      - OAUTH2_PROXY_CLIENT_SECRET=${IDMANAGER_AUTH_CLIENT_SECRET}
+      - OAUTH2_PROXY_COOKIE_SECRET=${IDMANAGER_AUTH_COOKIE_SECRET}
+      - OAUTH2_PROXY_COOKIE_DOMAINS=.${HOST}
+      - OAUTH2_PROXY_HTTP_ADDRESS=:4180
+      - OAUTH2_PROXY_REVERSE_PROXY=true
+      - OAUTH2_PROXY_WHITELIST_DOMAINS=.${HOST}
+      - OAUTH2_PROXY_UPSTREAMS=static://202
+      - OAUTH2_PROXY_EMAIL_DOMAINS=*
+      - OAUTH2_PROXY_SCOPE=openid profile email
+      # Pass Authorization Header and some user information to backend services
+      - OAUTH2_PROXY_SET_AUTHORIZATION_HEADER=true
+      - OAUTH2_PROXY_SET_XAUTHREQUEST=true
+      # Keycloak has an expiration time of 60s therefore oauth2-proxy needs to refresh after that
+      - OAUTH2_PROXY_COOKIE_REFRESH=60s
+      - OAUTH2_PROXY_ALLOWED_GROUPS=DKTK-CCP-PPSN
+      - OAUTH2_PROXY_PROXY_PREFIX=/oauth2-idm
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.traefik-forward-auth.loadbalancer.server.port=4180"
+      - "traefik.http.routers.oauth2.rule=PathPrefix(`/oauth2-idm/`)"
+      - "traefik.http.routers.oauth2.tls=true"
+      - "traefik.http.middlewares.traefik-forward-auth-idm.forwardauth.address=http://traefik-forward-auth:4180"
+      - "traefik.http.middlewares.traefik-forward-auth-idm.forwardauth.authResponseHeaders=Authorization"
+    depends_on:
+      forward_proxy:
+        condition: service_healthy
 
 volumes:
   patientlist-db-data:


### PR DESCRIPTION
This PR introduces a new way for Authentication in CCP ID-Management. Instead of Samply Auth, we use Keycloak as a provider. For this we added oauth2-proxy to handle the authentication and refactored the implementation in MagicPL to only do the check of the users access token and necessary groups. Unfortunately, i couldn't get it to work that we only have one installation of the oauth2-proxy running in the bridgehead. DataSHIELD still needs it's own, as both idm and datashield require a specific group for access and i was not able to separate this only in the labels.
Things we need to do before merging:
- [ ] Code Review for MagicPL
- [x] Test on Test Server (i provided an installation of this on our test bridgehead)
- [x] Create Clients for Bridgeheads in Keycloak

