### PR TITLE
Reduce bridgehead update interval to once a day at 6am

### DIFF
--- a/lib/systemd/bridgehead-update@.timer
+++ b/lib/systemd/bridgehead-update@.timer
@@ -2,7 +2,7 @@
 Description=Hourly Updates of Bridgehead (%i)
 
 [Timer]
-OnCalendar=*-*-* *:00:00
+OnCalendar=*-*-* 6:00:00
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Currently, the bridgehead updates every full hour. As we have more long-running processes, such as analyses and quality reports, these are interrupted by the update restart. 
Per our discussion, this PR reduces the update interval to once daily at 6am. 
This time point is after the docker registry replication time, hence, should have access to the newest docker images. 