### PR TITLE
Fixed environment variable passing for Directory sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,15 +306,12 @@ Full details can be found in [directory_sync_service](https://github.com/samply/
 To enable it, you will need to set these variables to the ```bbmri.conf``` file of your GitLab repository. Here is an example config:
 
 ```
-DS_DIRECTORY_URL=https://directory.bbmri-eric.eu
 DS_DIRECTORY_USER_NAME=your_directory_username
-DS_DIRECTORY_USER_PASS=qwdnqwswdvqHBVGFR9887
-DS_DIRECTORY_ALLOW_STAR_MODEL=true
-DS_TIMER_CRON="0 22 * * *"
+DS_DIRECTORY_USER_PASS=your_directory_password
 ```
-You must contact the Directory team for your national node to find the URL, and to register as a user.
+Please contact your National Node to obtain this information.
 
-Additionally, you should choose when you want Directory sync to run. In the example above, this is set to happen at 10 pm every evening. You can modify this to suit your requirements. The timer specification should follow the [cron](https://crontab.guru) convention.
+Optionally, you **may** change when you want Directory sync to run by specifying a [cron](https://crontab.guru) expression, e.g. `DS_TIMER_CRON="0 22 * * *"` for 10 pm every evening.
 
 Once you edited the gitlab config, the bridgehead will autoupdate the config with the values and will sync the data.
 

--- a/bbmri/modules/directory-sync-compose.yml
+++ b/bbmri/modules/directory-sync-compose.yml
@@ -4,12 +4,12 @@ services:
   directory_sync_service:
     image: "docker.verbis.dkfz.de/cache/samply/directory_sync_service"
     environment:
-      DS_DIRECTORY_URL: ${DS_DIRECTORY_URL}
+      DS_DIRECTORY_URL: ${DS_DIRECTORY_URL:-https://directory.bbmri-eric.eu}
       DS_DIRECTORY_USER_NAME: ${DS_DIRECTORY_USER_NAME}
       DS_DIRECTORY_USER_PASS: ${DS_DIRECTORY_USER_PASS}
-      DS_TIMER_CRON: ${DS_TIMER_CRON}
+      DS_TIMER_CRON: ${DS_TIMER_CRON:-0 22 * * *}
       # It is recommended to check the enabling of this flag with your local data protection group
-      DS_DIRECTORY_ALLOW_STAR_MODEL: ${DS_DIRECTORY_ALLOW_STAR_MODEL}
+      DS_DIRECTORY_ALLOW_STAR_MODEL: ${DS_DIRECTORY_ALLOW_STAR_MODEL:-true}
       DS_DIRECTORY_MOCK: ${DS_DIRECTORY_MOCK}
       DS_DIRECTORY_DEFAULT_COLLECTION_ID: ${DS_DIRECTORY_DEFAULT_COLLECTION_ID}
       DS_DIRECTORY_COUNTRY: ${DS_DIRECTORY_COUNTRY}

--- a/bbmri/modules/directory-sync-compose.yml
+++ b/bbmri/modules/directory-sync-compose.yml
@@ -6,7 +6,11 @@ services:
     environment:
       DS_DIRECTORY_URL: ${DS_DIRECTORY_URL}
       DS_DIRECTORY_USER_NAME: ${DS_DIRECTORY_USER_NAME}
-      DS_DIRECTORY_PASS_CODE: ${DS_DIRECTORY_PASS_CODE}
+      DS_DIRECTORY_USER_PASS: ${DS_DIRECTORY_USER_PASS}
       DS_TIMER_CRON: ${DS_TIMER_CRON}
       # It is recommended to check the enabling of this flag with your local data protection group
       DS_DIRECTORY_ALLOW_STAR_MODEL: ${DS_DIRECTORY_ALLOW_STAR_MODEL}
+      DS_DIRECTORY_MOCK: ${DS_DIRECTORY_MOCK}
+      DS_DIRECTORY_DEFAULT_COLLECTION_ID: ${DS_DIRECTORY_DEFAULT_COLLECTION_ID}
+      DS_DIRECTORY_COUNTRY: ${DS_DIRECTORY_COUNTRY}
+    command: sh -c "sleep 90 && java -jar directory_sync_service.jar" # Wait for Blaze before start

--- a/bbmri/modules/directory-sync-compose.yml
+++ b/bbmri/modules/directory-sync-compose.yml
@@ -13,6 +13,5 @@ services:
       DS_DIRECTORY_MOCK: ${DS_DIRECTORY_MOCK}
       DS_DIRECTORY_DEFAULT_COLLECTION_ID: ${DS_DIRECTORY_DEFAULT_COLLECTION_ID}
       DS_DIRECTORY_COUNTRY: ${DS_DIRECTORY_COUNTRY}
-    command: sh -c "sleep 90 && java -jar directory_sync_service.jar" # Wait for Blaze before start
     depends_on:
       - "blaze"

--- a/bbmri/modules/directory-sync-compose.yml
+++ b/bbmri/modules/directory-sync-compose.yml
@@ -14,3 +14,5 @@ services:
       DS_DIRECTORY_DEFAULT_COLLECTION_ID: ${DS_DIRECTORY_DEFAULT_COLLECTION_ID}
       DS_DIRECTORY_COUNTRY: ${DS_DIRECTORY_COUNTRY}
     command: sh -c "sleep 90 && java -jar directory_sync_service.jar" # Wait for Blaze before start
+    depends_on:
+      - "blaze"

--- a/bbmri/modules/directory-sync-compose.yml
+++ b/bbmri/modules/directory-sync-compose.yml
@@ -8,7 +8,6 @@ services:
       DS_DIRECTORY_USER_NAME: ${DS_DIRECTORY_USER_NAME}
       DS_DIRECTORY_USER_PASS: ${DS_DIRECTORY_USER_PASS}
       DS_TIMER_CRON: ${DS_TIMER_CRON:-0 22 * * *}
-      # It is recommended to check the enabling of this flag with your local data protection group
       DS_DIRECTORY_ALLOW_STAR_MODEL: ${DS_DIRECTORY_ALLOW_STAR_MODEL:-true}
       DS_DIRECTORY_MOCK: ${DS_DIRECTORY_MOCK}
       DS_DIRECTORY_DEFAULT_COLLECTION_ID: ${DS_DIRECTORY_DEFAULT_COLLECTION_ID}


### PR DESCRIPTION
There were problems with the passing of environment variables from bbmri.conf to the Directory synce container:

* The Directory password variable was misspellt.
* Some useful variables were missing.

Additionally, a delay was added before launching Directory sync, to give Blaze time to start up.