### PR TITLE
refactor: use environment variables for oauth2-proxy config

### DIFF
--- a/ccp/modules/datashield-compose.yml
+++ b/ccp/modules/datashield-compose.yml
@@ -121,42 +121,38 @@ services:
   oauth2-proxy:
     image: docker.verbis.dkfz.de/cache/oauth2-proxy/oauth2-proxy:latest
     container_name: bridgehead-oauth2proxy
-    command: >-
-      --allowed-group=DataSHIELD
-      --oidc-groups-claim=${OIDC_GROUP_CLAIM}
-      --auth-logging=true
-      --whitelist-domain=${HOST}
-      --http-address="0.0.0.0:4180"
-      --reverse-proxy=true
-      --upstream="static://202"
-      --email-domain="*"
-      --cookie-name="_BRIDGEHEAD_oauth2"
-      --cookie-secret="${OAUTH2_PROXY_SECRET}"
-      --cookie-expire="12h"
-      --cookie-secure="true"
-      --cookie-httponly="true"
+    environment:
+      - http_proxy=http://forward_proxy:3128
+      - https_proxy=http://forward_proxy:3128
+      - OAUTH2_PROXY_ALLOWED_GROUPS=DataSHIELD
+      - OAUTH2_PROXY_OIDC_GROUPS_CLAIM=${OIDC_GROUP_CLAIM}
+      - OAUTH2_PROXY_WHITELIST_DOMAIN=${HOST}
+      - OAUTH2_PROXY_HTTP_ADDRESS=:4180
+      - OAUTH2_PROXY_REVERSE_PROXY=true
+      - OAUTH2_PROXY_UPSTREAMS=static://202
+      - OAUTH2_PROXY_EMAIL_DOMAINS=*
+      - OAUTH2_PROXY_COOKIE_NAME=_BRIDGEHEAD_oauth2
+      - OAUTH2_PROXY_COOKIE_SECRET=${OAUTH2_PROXY_SECRET}
+      - OAUTH2_PROXY_COOKIE_EXPIRE=12h
       #OIDC settings
-      --provider="keycloak-oidc"
-      --provider-display-name="VerbIS Login"
-      --client-id="${OIDC_PRIVATE_CLIENT_ID}"
-      --client-secret="${OIDC_CLIENT_SECRET}"
-      --redirect-url="https://${HOST}${OAUTH2_CALLBACK}"
-      --oidc-issuer-url="${OIDC_ISSUER_URL}"
-      --scope="openid email profile"
-      --code-challenge-method="S256"
-      --skip-provider-button=true
+      - OAUTH2_PROXY_PROVIDER=keycloak-oidc
+      - OAUTH2_PROXY_PROVIDER_DISPLAY_NAME="VerbIS Login"
+      - OAUTH2_PROXY_CLIENT_ID=${OIDC_PRIVATE_CLIENT_ID}
+      - OAUTH2_PROXY_CLIENT_SECRET=${OIDC_CLIENT_SECRET}
+      - OAUTH2_PROXY_REDIRECT_URL="https://${HOST}${OAUTH2_CALLBACK}"
+      - OAUTH2_PROXY_OIDC_ISSUER_URL=${OIDC_ISSUER_URL}
+      - OAUTH2_PROXY_SCOPE=openid profile email
+      - OAUTH2_PROXY_CODE_CHALLENGE_METHOD=true
+      - OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true
       #X-Forwarded-Header settings - true/false depending on your needs
-      --pass-basic-auth=true
-      --pass-user-headers=false
-      --pass-access-token=false
+      - OAUTH2_PROXY_PASS_BASIC_AUTH=true
+      - OAUTH2_PROXY_PASS_USER_HEADERS=false
+      - OAUTH2_PROXY_ACCESS_TOKEN=false
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.oauth2_proxy.rule=PathPrefix(`/oauth2`)"
       - "traefik.http.services.oauth2_proxy.loadbalancer.server.port=4180"
       - "traefik.http.routers.oauth2_proxy.tls=true"
-    environment:
-      http_proxy: "http://forward_proxy:3128"
-      https_proxy: "http://forward_proxy:3128"
     depends_on:
       forward_proxy:
         condition: service_healthy


### PR DESCRIPTION
Adjust the configuration of both oauth2-proxy instances to use environment variables for configuration. 