### PR TITLE
feat: added blaze cql cache

### DIFF
--- a/bbmri/docker-compose.yml
+++ b/bbmri/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       BASE_URL: "http://bridgehead-bbmri-blaze:8080"
       JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP:-4096}m"
       DB_RESOURCE_CACHE_SIZE: ${BLAZE_RESOURCE_CACHE_CAP:-2500000}
-      DB_BLOCK_CACHE_SIZE: $BLAZE_MEMORY_CAP
+      DB_BLOCK_CACHE_SIZE: ${BLAZE_MEMORY_CAP}
+      CQL_EXPR_CACHE_SIZE: ${BLAZE_CQL_CACHE_CAP:-32}
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     volumes:
       - "blaze-data:/app/data"

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       BASE_URL: "http://bridgehead-ccp-blaze:8080"
       JAVA_TOOL_OPTIONS: "-Xmx${BLAZE_MEMORY_CAP:-4096}m"
       DB_RESOURCE_CACHE_SIZE: ${BLAZE_RESOURCE_CACHE_CAP:-2500000}
-      DB_BLOCK_CACHE_SIZE: $BLAZE_MEMORY_CAP
+      DB_BLOCK_CACHE_SIZE: ${BLAZE_MEMORY_CAP}
+      CQL_EXPR_CACHE_SIZE: ${BLAZE_CQL_CACHE_CAP:-32}
       ENFORCE_REFERENTIAL_INTEGRITY: "false"
     volumes:
       - "blaze-data:/app/data"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -171,8 +171,10 @@ optimizeBlazeMemoryUsage() {
 		if [ $available_system_memory_chunks -eq 0 ]; then
 			log WARN "Only ${BLAZE_MEMORY_CAP} system memory available for Blaze. If your Blaze stores more than 128000 fhir ressources it will run significally slower."
 			export BLAZE_RESOURCE_CACHE_CAP=128000;
+			export BLAZE_CQL_CACHE_CAP=32;
 		else
 			export BLAZE_RESOURCE_CACHE_CAP=$((available_system_memory_chunks * 312500))
+			export BLAZE_CQL_CACHE_CAP=$((($system_memory_in_mb/4)/16));
 		fi
 	fi
 }


### PR DESCRIPTION
This PR sets a calculated CQL cache value to Blaze. It's been tested locally and on one bridgehead and the performance gains are ok to good. I didn't test if the amount of cache if too low or too much, I think this needs to be tested in the long term.