### PR TITLE
Feat/ccp ppi

### DIFF
--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -57,6 +57,11 @@ services:
       - /etc/bridgehead/trusted-ca-certs:/conf/trusted-ca-certs:ro
       - /srv/docker/bridgehead/ccp/root.crt.pem:/conf/root.crt.pem:ro
 
+  ccp-patient-project-identificator:
+    image: samply/ccp-patient-project-identificator
+    environment:
+      MAINZELLISTE_APIKEY: ${MAINZELLISTE_APIKEY}
+      SITE_NAME: ${SITE_NAME}
 
 volumes:
   blaze-data:

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -59,8 +59,9 @@ services:
 
   ccp-patient-project-identificator:
     image: samply/ccp-patient-project-identificator
+    container_name: bridgehead-ccp-patient-project-identificator
     environment:
-      MAINZELLISTE_APIKEY: ${MAINZELLISTE_APIKEY}
+      MAINZELLISTE_APIKEY: ${IDMANAGER_LOCAL_PATIENTLIST_APIKEY}
       SITE_NAME: ${SITE_NAME}
 
 volumes:

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -57,13 +57,6 @@ services:
       - /etc/bridgehead/trusted-ca-certs:/conf/trusted-ca-certs:ro
       - /srv/docker/bridgehead/ccp/root.crt.pem:/conf/root.crt.pem:ro
 
-  ccp-patient-project-identificator:
-    image: samply/ccp-patient-project-identificator
-    container_name: bridgehead-ccp-patient-project-identificator
-    environment:
-      MAINZELLISTE_APIKEY: ${IDMANAGER_LOCAL_PATIENTLIST_APIKEY}
-      SITE_NAME: ${SITE_NAME}
-
 volumes:
   blaze-data:
 

--- a/ccp/modules/id-management-compose.yml
+++ b/ccp/modules/id-management-compose.yml
@@ -101,5 +101,12 @@ services:
       forward_proxy:
         condition: service_healthy
 
+  ccp-patient-project-identificator:
+    image: samply/ccp-patient-project-identificator
+    container_name: bridgehead-ccp-patient-project-identificator
+    environment:
+      MAINZELLISTE_APIKEY: ${IDMANAGER_LOCAL_PATIENTLIST_APIKEY}
+      SITE_NAME: ${SITE_NAME}
+
 volumes:
   patientlist-db-data:


### PR DESCRIPTION
This PR adds the ccp-patient-project-idenficator to the bridgehead. The ccp-ppi is a component that connects blaze and mainzellist to load patient spefific pseudonymes to blaze. The component searches for patients in the Mainzelliste and search for those patients in blaze.

This makes it possible to search project specific, later it will copy the pseudonymes.