### PR TITLE
Add exporter configuration to focus

### DIFF
--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       RETRY_COUNT: ${FOCUS_RETRY_COUNT}
       EPSILON: 0.28
       QUERIES_TO_CACHE: '/queries_to_cache.conf'
+      EXPORTER_URL: "http://exporter:8092"
+      AUTH_HEADER: "${EXPORTER_API_KEY}"
     volumes:
       - /srv/docker/bridgehead/ccp/queries_to_cache.conf:/queries_to_cache.conf
     depends_on:

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       QUERIES_TO_CACHE: '/queries_to_cache.conf'
       EXPORTER_URL: "http://exporter:8092"
       AUTH_HEADER: "${EXPORTER_API_KEY}"
+      ENDPOINT_TYPE: ${FOCUS_ENDPOINT_TYPE:-blaze}
     volumes:
       - /srv/docker/bridgehead/ccp/queries_to_cache.conf:/queries_to_cache.conf
     depends_on:
@@ -59,7 +60,6 @@ services:
     volumes:
       - /etc/bridgehead/trusted-ca-certs:/conf/trusted-ca-certs:ro
       - /srv/docker/bridgehead/ccp/root.crt.pem:/conf/root.crt.pem:ro
-
 
 volumes:
   blaze-data:

--- a/ccp/modules/fhir2sql-compose.yml
+++ b/ccp/modules/fhir2sql-compose.yml
@@ -23,3 +23,7 @@ services:
       POSTGRES_DB: "dashboard"
     volumes:
       - "/var/cache/bridgehead/ccp/dashboard-db:/var/lib/postgresql/data"
+
+  focus:
+    environment:
+      POSTGRES_CONNECTION_STRING: "postgresql://dashboard:${DASHBOARD_DB_PASSWORD}@dashboard-db/dashboard"

--- a/ccp/modules/fhir2sql-setup.sh
+++ b/ccp/modules/fhir2sql-setup.sh
@@ -4,4 +4,5 @@ if [ "$ENABLE_FHIR2SQL" == true ]; then
   log INFO "Dashboard setup detected -- will start Dashboard backend and FHIR2SQL service."
   OVERRIDE+=" -f ./$PROJECT/modules/fhir2sql-compose.yml"
   DASHBOARD_DB_PASSWORD="$(generate_simple_password 'fhir2sql')"
+  FOCUS_ENDPOINT_TYPE="blaze-and-sql"
 fi

--- a/ccp/modules/id-management-compose.yml
+++ b/ccp/modules/id-management-compose.yml
@@ -101,5 +101,12 @@ services:
       forward_proxy:
         condition: service_healthy
 
+  ccp-patient-project-identificator:
+    image: samply/ccp-patient-project-identificator
+    container_name: bridgehead-ccp-patient-project-identificator
+    environment:
+      MAINZELLISTE_APIKEY: ${IDMANAGER_LOCAL_PATIENTLIST_APIKEY}
+      SITE_NAME: ${SITE_NAME}
+
 volumes:
   patientlist-db-data:


### PR DESCRIPTION
Add exporter configuration in focus for  CCP in order to accept queries trough beam from central project manager (data science orchestrator)