### PR TITLE
Add exporter configuration to focus

### DIFF
--- a/ccp/modules/exporter-compose.yml
+++ b/ccp/modules/exporter-compose.yml
@@ -65,3 +65,8 @@ services:
       - "traefik.http.routers.reporter_ccp.tls=true"
       - "traefik.http.middlewares.reporter_ccp_strip.stripprefix.prefixes=/ccp-reporter"
       - "traefik.http.routers.reporter_ccp.middlewares=reporter_ccp_strip"
+
+  focus:
+    environment:
+      EXPORTER_URL: "http://exporter:8092"
+      AUTH_HEADER: "${EXPORTER_API_KEY}"


### PR DESCRIPTION
Add exporter configuration in focus for CCP in order to accept queries trough beam from central project manager (data science orchestrator)