### PR TITLE
fix: use verbis cache image instead of docker-hub

### DIFF
--- a/ccp/modules/id-management-compose.yml
+++ b/ccp/modules/id-management-compose.yml
@@ -102,7 +102,7 @@ services:
         condition: service_healthy
 
   ccp-patient-project-identificator:
-    image: samply/ccp-patient-project-identificator
+    image: docker.verbis.dkfz.de/cache/samply/ccp-patient-project-identificator
     container_name: bridgehead-ccp-patient-project-identificator
     environment:
       MAINZELLISTE_APIKEY: ${IDMANAGER_LOCAL_PATIENTLIST_APIKEY}


### PR DESCRIPTION
This PR change the image url to verbis cache.