### PR TITLE
feat: migrate to new dnpm:dip node

### DIFF
--- a/ccp/modules/dnpm-compose.yml
+++ b/ccp/modules/dnpm-compose.yml
@@ -13,7 +13,7 @@ services:
       PROXY_APIKEY: ${DNPM_BEAM_SECRET_SHORT}
       APP_ID: dnpm-connect.${PROXY_ID}
       DISCOVERY_URL: "./conf/central_targets.json"
-      LOCAL_TARGETS_FILE: "./conf/connect_targets.json"
+      LOCAL_TARGETS_FILE: "/conf/connect_targets.json"
       HTTP_PROXY: "http://forward_proxy:3128"
       HTTPS_PROXY: "http://forward_proxy:3128"
       NO_PROXY: beam-proxy,dnpm-backend,host.docker.internal${DNPM_ADDITIONAL_NO_PROXY}
@@ -25,7 +25,7 @@ services:
     volumes:
       - /etc/bridgehead/trusted-ca-certs:/conf/trusted-ca-certs:ro
       - /etc/bridgehead/dnpm/local_targets.json:/conf/connect_targets.json:ro
-      - /etc/bridgehead/dnpm/central_targets.json:/conf/central_targets.json:ro
+      - /srv/docker/bridgehead/minimal/modules/dnpm-central-targets.json:/conf/central_targets.json:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.dnpm-connect.rule=PathPrefix(`/dnpm-connect`)"

--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -64,7 +64,7 @@ services:
       - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
       - MTB_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
       - HATEOAS_HOST=https://${HOST}
-      - CONNECTOR_TYPE=${BACKEND_CONNECTOR_TYPE:-broker}
+      - CONNECTOR_TYPE=broker
       - AUTHUP_URL=robot://system:${DNPM_AUTHUP_SECRET}@http://dnpm-authup:3000
     volumes:
       - /etc/bridgehead/dnpm/config:/dnpm_config

--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -1,34 +1,88 @@
 version: "3.7"
 
 services:
-  dnpm-backend:
-    image: ghcr.io/kohlbacherlab/bwhc-backend:1.0-snapshot-broker-connector
-    container_name: bridgehead-dnpm-backend
+  dnpm-mysql:
+    image: mysql:latest
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      interval: 3s
+      timeout: 5s
+      retries: 5
     environment:
-      - ZPM_SITE=${ZPM_SITE}
-      - N_RANDOM_FILES=${DNPM_SYNTH_NUM}
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_ROOT_PASSWORD: ${DNPM_MYSQL_ROOT_PASSWORD}
     volumes:
-      - /etc/bridgehead/dnpm:/bwhc_config:ro
-      - ${DNPM_DATA_DIR}:/bwhc_data
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.bwhc-backend.rule=PathPrefix(`/bwhc`)"
-      - "traefik.http.services.bwhc-backend.loadbalancer.server.port=9000"
-      - "traefik.http.routers.bwhc-backend.tls=true"
+      - dnpm-mysql:/var/lib/mysql
 
-  dnpm-frontend:
-    image: ghcr.io/kohlbacherlab/bwhc-frontend:2209
-    container_name: bridgehead-dnpm-frontend
-    links:
-      - dnpm-backend
+  dnpm-authup:
+    image: authup/authup:latest
+    container_name: bridgehead-dnpm-authup
+    volumes:
+      - dnpm-authup:/usr/src/app/writable
+    depends_on:
+      dnpm-mysql:
+        condition: service_healthy
+    command: server/core start
     environment:
-      - NUXT_HOST=0.0.0.0
-      - NUXT_PORT=8080
-      - BACKEND_PROTOCOL=https
-      - BACKEND_HOSTNAME=$HOST
-      - BACKEND_PORT=443
+      - PUBLIC_URL=https://${HOST}/auth/
+      - AUTHORIZE_REDIRECT_URL=https://${HOST}
+      - ROBOT_ADMIN_ENABLED=true
+      - ROBOT_ADMIN_SECRET=${DNPM_AUTHUP_SECRET}
+      - ROBOT_ADMIN_SECRET_RESET=true
+      - DB_TYPE=mysql
+      - DB_HOST=dnpm-mysql
+      - DB_USERNAME=root
+      - DB_PASSWORD=${DNPM_MYSQL_ROOT_PASSWORD}
+      - DB_DATABASE=auth
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.bwhc-frontend.rule=PathPrefix(`/`)"
-      - "traefik.http.services.bwhc-frontend.loadbalancer.server.port=8080"
-      - "traefik.http.routers.bwhc-frontend.tls=true"
+      - "traefik.http.middlewares.authup-strip.stripprefix.prefixes=/auth"
+      - "traefik.http.routers.dnpm-auth.middlewares=authup-strip"
+      - "traefik.http.routers.dnpm-auth.rule=PathPrefix(`/auth`)"
+      - "traefik.http.services.dnpm-auth.loadbalancer.server.port=3000"
+      - "traefik.http.routers.dnpm-auth.tls=true"
+
+  dnpm-portal:
+    image: ghcr.io/kohlbacherlab/dnpm-dip-portal:latest
+    container_name: bridgehead-dnpm-portal
+    environment:
+      - NUXT_API_URL=http://dnpm-backend:9000/
+      - NUXT_PUBLIC_API_URL=https://${HOST}/api/
+      - NUXT_AUTHUP_URL=http://dnpm-authup:3000/
+      - NUXT_PUBLIC_AUTHUP_URL=https://${HOST}/auth/
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dnpm-frontend.rule=PathPrefix(`/`)"
+      - "traefik.http.services.dnpm-frontend.loadbalancer.server.port=3000"
+      - "traefik.http.routers.dnpm-frontend.tls=true"
+
+  dnpm-backend:
+    container_name: bridgehead-dnpm-backend
+    image: ghcr.io/kohlbacherlab/dnpm-dip-backend:latest
+    environment:
+      - LOCAL_SITE=${ZPM_SITE}:${SITE_ID}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
+      - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
+      - MTB_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
+      - HATEOAS_HOST=https://${HOST}
+      - CONNECTOR_TYPE=${BACKEND_CONNECTOR_TYPE:-broker}
+      - AUTHUP_URL=robot://system:${DNPM_AUTHUP_SECRET}@http://dnpm-authup:3000
+    volumes:
+      - /etc/bridgehead/dnpm/config:/dnpm_config
+      - dnpm-backend-data:/dnpm_data
+    depends_on:
+      dnpm-authup:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dnpm-backend.rule=PathPrefix(`/api`)"
+      - "traefik.http.services.dnpm-backend.loadbalancer.server.port=9000"
+      - "traefik.http.routers.dnpm-backend.tls=true"
+
+  landing:
+    labels:
+      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"
+
+volumes:
+  dnpm-authup:
+  dnpm-mysql:
+  dnpm-backend-data:

--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   dnpm-mysql:
-    image: mysql:latest
+    image: mysql:9
     healthcheck:
       test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
       interval: 3s

--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -43,7 +43,7 @@ services:
       - "traefik.http.routers.dnpm-auth.tls=true"
 
   dnpm-portal:
-    image: ghcr.io/kohlbacherlab/dnpm-dip-portal:latest
+    image: ghcr.io/dnpm-dip/portal:latest
     container_name: bridgehead-dnpm-portal
     environment:
       - NUXT_API_URL=http://dnpm-backend:9000/
@@ -58,7 +58,7 @@ services:
 
   dnpm-backend:
     container_name: bridgehead-dnpm-backend
-    image: ghcr.io/kohlbacherlab/dnpm-dip-backend:latest
+    image: ghcr.io/dnpm-dip/backend:latest
     environment:
       - LOCAL_SITE=${ZPM_SITE}:${SITE_NAME}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
       - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}

--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -60,7 +60,7 @@ services:
     container_name: bridgehead-dnpm-backend
     image: ghcr.io/kohlbacherlab/dnpm-dip-backend:latest
     environment:
-      - LOCAL_SITE=${ZPM_SITE}:${SITE_ID}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
+      - LOCAL_SITE=${ZPM_SITE}:${SITE_NAME}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
       - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
       - MTB_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
       - HATEOAS_HOST=https://${HOST}

--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -74,9 +74,25 @@ services:
         condition: service_healthy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.dnpm-backend.rule=PathPrefix(`/api`)"
       - "traefik.http.services.dnpm-backend.loadbalancer.server.port=9000"
+      # expose everything
+      - "traefik.http.routers.dnpm-backend.rule=PathPrefix(`/api`)"
       - "traefik.http.routers.dnpm-backend.tls=true"
+      - "traefik.http.routers.dnpm-backend.service=dnpm-backend"
+      # except ETL
+      - "traefik.http.routers.dnpm-backend-etl.rule=PathRegexp(`^/api(/.*)?etl(/.*)?$`)"
+      - "traefik.http.routers.dnpm-backend-etl.tls=true"
+      - "traefik.http.routers.dnpm-backend-etl.service=dnpm-backend"
+      # this needs an ETL processor with support for basic auth
+      - "traefik.http.routers.dnpm-backend-etl.middlewares=auth"
+      # except peer-to-peer
+      - "traefik.http.routers.dnpm-backend-peer.rule=PathRegexp(`^/api(/.*)?/peer2peer(/.*)?$`)"
+      - "traefik.http.routers.dnpm-backend-peer.tls=true"
+      - "traefik.http.routers.dnpm-backend-peer.service=dnpm-backend"
+      - "traefik.http.routers.dnpm-backend-peer.middlewares=dnpm-backend-peer"
+      # this effectively denies all requests
+      # this is okay, because requests from peers don't go through Traefik
+      - "traefik.http.middlewares.dnpm-backend-peer.ipWhiteList.sourceRange=0.0.0.0/32"
 
   landing:
     labels:

--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -12,13 +12,13 @@ services:
       MYSQL_ROOT_HOST: "%"
       MYSQL_ROOT_PASSWORD: ${DNPM_MYSQL_ROOT_PASSWORD}
     volumes:
-      - dnpm-mysql:/var/lib/mysql
+      - /var/cache/bridgehead/dnpm/mysql:/var/lib/mysql
 
   dnpm-authup:
     image: authup/authup:latest
     container_name: bridgehead-dnpm-authup
     volumes:
-      - dnpm-authup:/usr/src/app/writable
+      - /var/cache/bridgehead/dnpm/authup:/usr/src/app/writable
     depends_on:
       dnpm-mysql:
         condition: service_healthy
@@ -68,7 +68,7 @@ services:
       - AUTHUP_URL=robot://system:${DNPM_AUTHUP_SECRET}@http://dnpm-authup:3000
     volumes:
       - /etc/bridgehead/dnpm/config:/dnpm_config
-      - dnpm-backend-data:/dnpm_data
+      - /var/cache/bridgehead/dnpm/backend-data:/dnpm_data
     depends_on:
       dnpm-authup:
         condition: service_healthy
@@ -81,8 +81,3 @@ services:
   landing:
     labels:
       - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"
-
-volumes:
-  dnpm-authup:
-  dnpm-mysql:
-  dnpm-backend-data:

--- a/ccp/modules/dnpm-node-setup.sh
+++ b/ccp/modules/dnpm-node-setup.sh
@@ -10,7 +10,7 @@ if [ -n "${ENABLE_DNPM_NODE}" ]; then
 		exit 1
 	fi
     mkdir -p /var/cache/bridgehead/dnpm/ || fail_and_report 1 "Failed to create '/var/cache/bridgehead/dnpm/'. Please run sudo './bridgehead install $PROJECT' again to fix the permissions."
-	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:--1}
+    DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:--1}
     DNPM_MYSQL_ROOT_PASSWORD="$(generate_simple_password 'dnpm mysql')"
     DNPM_AUTHUP_SECRET="$(generate_simple_password 'dnpm authup')"
 fi

--- a/ccp/modules/dnpm-node-setup.sh
+++ b/ccp/modules/dnpm-node-setup.sh
@@ -1,28 +1,15 @@
 #!/bin/bash
 
 if [ -n "${ENABLE_DNPM_NODE}" ]; then
-	log INFO "DNPM setup detected (BwHC Node) -- will start BwHC node."
+	log INFO "DNPM setup detected -- will start DNPM:DIP node."
 	OVERRIDE+=" -f ./$PROJECT/modules/dnpm-node-compose.yml"
 
 	# Set variables required for BwHC Node. ZPM_SITE is assumed to be set in /etc/bridgehead/<project>.conf
-	DNPM_APPLICATION_SECRET="$(echo \"This is a salt string to generate one consistent password for DNPM. It is not required to be secret.\" | sha1sum | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
 	if [ -z "${ZPM_SITE+x}" ]; then
 		log ERROR "Mandatory variable ZPM_SITE not defined!"
 		exit 1
 	fi
-	if [ -z "${DNPM_DATA_DIR+x}" ]; then
-		log ERROR "Mandatory variable DNPM_DATA_DIR not defined!"
-		exit 1
-	fi
-	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:-0}
-	if grep -q 'traefik.http.routers.landing.rule=PathPrefix(`/landing`)' /srv/docker/bridgehead/minimal/docker-compose.override.yml 2>/dev/null; then
-		echo "Override of landing page url already in place"
-	else
-		echo "Adding override of landing page url"
-		if [ -f /srv/docker/bridgehead/minimal/docker-compose.override.yml ]; then
-			echo -e '  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
-		else
-			echo -e 'version: "3.7"\nservices:\n  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
-		fi
-	fi
+	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:--1}
+    DNPM_MYSQL_ROOT_PASSWORD="$(generate_simple_password 'dnpm mysql')"
+    DNPM_AUTHUP_SECRET="$(generate_simple_password 'dnpm authup')"
 fi

--- a/ccp/modules/dnpm-node-setup.sh
+++ b/ccp/modules/dnpm-node-setup.sh
@@ -9,6 +9,7 @@ if [ -n "${ENABLE_DNPM_NODE}" ]; then
 		log ERROR "Mandatory variable ZPM_SITE not defined!"
 		exit 1
 	fi
+    mkdir -p /var/cache/bridgehead/dnpm/ || fail_and_report 1 "Failed to create '/var/cache/bridgehead/dnpm/'. Please run sudo './bridgehead install $PROJECT' again to fix the permissions."
 	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:--1}
     DNPM_MYSQL_ROOT_PASSWORD="$(generate_simple_password 'dnpm mysql')"
     DNPM_AUTHUP_SECRET="$(generate_simple_password 'dnpm authup')"

--- a/minimal/docker-compose.yml
+++ b/minimal/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - --entrypoints.web.http.redirections.entrypoint.scheme=https
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.dashboard.rule=PathPrefix(`/api`) || PathPrefix(`/dashboard/`)"
+      - "traefik.http.routers.dashboard.rule=PathPrefix(`/dashboard/`)"
       - "traefik.http.routers.dashboard.entrypoints=websecure"
       - "traefik.http.routers.dashboard.service=api@internal"
       - "traefik.http.routers.dashboard.tls=true"

--- a/minimal/modules/dnpm-central-targets.json
+++ b/minimal/modules/dnpm-central-targets.json
@@ -127,6 +127,12 @@
             "beamconnect": "dnpm-connect.wuerzburg-dnpm.broker.ccp-it.dktk.dkfz.de"
         },
         {
+            "id": "UKSH",
+            "name": "Schleswig-Holstein",
+            "virtualhost": "uksh.dnpm.de",
+            "beamconnect": "dnpm-connect.uksh-dnpm.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
             "id": "TKT",
             "name": "Test",
             "virtualhost": "tkt.dnpm.de",

--- a/minimal/modules/dnpm-central-targets.json
+++ b/minimal/modules/dnpm-central-targets.json
@@ -118,7 +118,7 @@
             "id": "UMG",
             "name": "Goettingen",
             "virtualhost": "umg.dnpm.de",
-            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+            "beamconnect": "dnpm-connect.goettingen.broker.ccp-it.dktk.dkfz.de"
         },
         {
             "id": "UKW",

--- a/minimal/modules/dnpm-central-targets.json
+++ b/minimal/modules/dnpm-central-targets.json
@@ -1,0 +1,136 @@
+{
+    "sites": [
+        {
+            "id": "UKFR",
+            "name": "Freiburg",
+            "virtualhost": "ukfr.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKHD",
+            "name": "Heidelberg",
+            "virtualhost": "ukhd.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKT",
+            "name": "Tübingen",
+            "virtualhost": "ukt.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKU",
+            "name": "Ulm",
+            "virtualhost": "uku.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UM",
+            "name": "Mainz",
+            "virtualhost": "um.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKMR",
+            "name": "Marburg",
+            "virtualhost": "ukmr.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKE",
+            "name": "Hamburg",
+            "virtualhost": "uke.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKA",
+            "name": "Aachen",
+            "virtualhost": "uka.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "Charite",
+            "name": "Berlin",
+            "virtualhost": "charite.dnpm.de",
+            "beamconnect": "dnpm-connect.berlin-test.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "MRI",
+            "name": "Muenchen-tum",
+            "virtualhost": "mri.dnpm.de",
+            "beamconnect": "dnpm-connect.muenchen-tum.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "KUM",
+            "name": "Muenchen-lmu",
+            "virtualhost": "kum.dnpm.de",
+            "beamconnect": "dnpm-connect.muenchen-lmu.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "MHH",
+            "name": "Hannover",
+            "virtualhost": "mhh.dnpm.de",
+            "beamconnect": "dnpm-connect.hannover.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKDD",
+            "name": "dresden-dnpm",
+            "virtualhost": "ukdd.dnpm.de",
+            "beamconnect": "dnpm-connect.dresden-dnpm.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKB",
+            "name": "Bonn",
+            "virtualhost": "ukb.dnpm.de",
+            "beamconnect": "dnpm-connect.bonn-dnpm.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKD",
+            "name": "Duesseldorf",
+            "virtualhost": "ukd.dnpm.de",
+            "beamconnect": "dnpm-connect.duesseldorf-dnpm.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKK",
+            "name": "Koeln",
+            "virtualhost": "ukk.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UME",
+            "name": "Essen",
+            "virtualhost": "ume.dnpm.de",
+            "beamconnect": "dnpm-connect.essen.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKM",
+            "name": "Muenster",
+            "virtualhost": "ukm.dnpm.de",
+            "beamconnect": "dnpm-connect.muenster-dnpm.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKF",
+            "name": "Frankfurt",
+            "virtualhost": "ukf.dnpm.de",
+            "beamconnect": "dnpm-connect.frankfurt.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UMG",
+            "name": "Goettingen",
+            "virtualhost": "umg.dnpm.de",
+            "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "UKW",
+            "name": "Würzburg",
+            "virtualhost": "ukw.dnpm.de",
+            "beamconnect": "dnpm-connect.wuerzburg-dnpm.broker.ccp-it.dktk.dkfz.de"
+        },
+        {
+            "id": "TKT",
+            "name": "Test",
+            "virtualhost": "tkt.dnpm.de",
+            "beamconnect": "dnpm-connect.tobias-develop.broker.ccp-it.dktk.dkfz.de"
+        }
+    ]
+}

--- a/minimal/modules/dnpm-compose.yml
+++ b/minimal/modules/dnpm-compose.yml
@@ -29,7 +29,7 @@ services:
       PROXY_APIKEY: ${DNPM_BEAM_SECRET_SHORT}
       APP_ID: dnpm-connect.${DNPM_PROXY_ID}
       DISCOVERY_URL: "./conf/central_targets.json"
-      LOCAL_TARGETS_FILE: "./conf/connect_targets.json"
+      LOCAL_TARGETS_FILE: "/conf/connect_targets.json"
       HTTP_PROXY: http://forward_proxy:3128
       HTTPS_PROXY: http://forward_proxy:3128
       NO_PROXY: dnpm-beam-proxy,dnpm-backend, host.docker.internal${DNPM_ADDITIONAL_NO_PROXY}
@@ -41,7 +41,7 @@ services:
     volumes:
       - /etc/bridgehead/trusted-ca-certs:/conf/trusted-ca-certs:ro
       - /etc/bridgehead/dnpm/local_targets.json:/conf/connect_targets.json:ro
-      - /etc/bridgehead/dnpm/central_targets.json:/conf/central_targets.json:ro
+      - /srv/docker/bridgehead/minimal/modules/dnpm-central-targets.json:/conf/central_targets.json:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.dnpm-connect.rule=PathPrefix(`/dnpm-connect`)"

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -64,7 +64,7 @@ services:
       - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
       - MTB_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
       - HATEOAS_HOST=https://${HOST}
-      - CONNECTOR_TYPE=${BACKEND_CONNECTOR_TYPE:-broker}
+      - CONNECTOR_TYPE=broker
       - AUTHUP_URL=robot://system:${DNPM_AUTHUP_SECRET}@http://dnpm-authup:3000
     volumes:
       - /etc/bridgehead/dnpm/config:/dnpm_config

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -1,34 +1,88 @@
 version: "3.7"
 
 services:
-  dnpm-backend:
-    image: ghcr.io/kohlbacherlab/bwhc-backend:1.0-snapshot-broker-connector
-    container_name: bridgehead-dnpm-backend
+  dnpm-mysql:
+    image: mysql:latest
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      interval: 3s
+      timeout: 5s
+      retries: 5
     environment:
-      - ZPM_SITE=${ZPM_SITE}
-      - N_RANDOM_FILES=${DNPM_SYNTH_NUM}
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_ROOT_PASSWORD: ${DNPM_MYSQL_ROOT_PASSWORD}
     volumes:
-      - /etc/bridgehead/dnpm:/bwhc_config:ro
-      - ${DNPM_DATA_DIR}:/bwhc_data
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.bwhc-backend.rule=PathPrefix(`/bwhc`)"
-      - "traefik.http.services.bwhc-backend.loadbalancer.server.port=9000"
-      - "traefik.http.routers.bwhc-backend.tls=true"
+      - dnpm-mysql:/var/lib/mysql
 
-  dnpm-frontend:
-    image: ghcr.io/kohlbacherlab/bwhc-frontend:2209
-    container_name: bridgehead-dnpm-frontend
-    links:
-      - dnpm-backend
+  dnpm-authup:
+    image: authup/authup:latest
+    container_name: bridgehead-dnpm-authup
+    volumes:
+      - dnpm-authup:/usr/src/app/writable
+    depends_on:
+      dnpm-mysql:
+        condition: service_healthy
+    command: server/core start
     environment:
-      - NUXT_HOST=0.0.0.0
-      - NUXT_PORT=8080
-      - BACKEND_PROTOCOL=https
-      - BACKEND_HOSTNAME=$HOST
-      - BACKEND_PORT=443
+      - PUBLIC_URL=https://${HOST}/auth/
+      - AUTHORIZE_REDIRECT_URL=https://${HOST}
+      - ROBOT_ADMIN_ENABLED=true
+      - ROBOT_ADMIN_SECRET=${DNPM_AUTHUP_SECRET}
+      - ROBOT_ADMIN_SECRET_RESET=true
+      - DB_TYPE=mysql
+      - DB_HOST=dnpm-mysql
+      - DB_USERNAME=root
+      - DB_PASSWORD=${DNPM_MYSQL_ROOT_PASSWORD}
+      - DB_DATABASE=auth
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.bwhc-frontend.rule=PathPrefix(`/`)"
-      - "traefik.http.services.bwhc-frontend.loadbalancer.server.port=8080"
-      - "traefik.http.routers.bwhc-frontend.tls=true"
+      - "traefik.http.middlewares.authup-strip.stripprefix.prefixes=/auth"
+      - "traefik.http.routers.dnpm-auth.middlewares=authup-strip"
+      - "traefik.http.routers.dnpm-auth.rule=PathPrefix(`/auth`)"
+      - "traefik.http.services.dnpm-auth.loadbalancer.server.port=3000"
+      - "traefik.http.routers.dnpm-auth.tls=true"
+
+  dnpm-portal:
+    image: ghcr.io/kohlbacherlab/dnpm-dip-portal:latest
+    container_name: bridgehead-dnpm-portal
+    environment:
+      - NUXT_API_URL=http://dnpm-backend:9000/
+      - NUXT_PUBLIC_API_URL=https://${HOST}/api/
+      - NUXT_AUTHUP_URL=http://dnpm-authup:3000/
+      - NUXT_PUBLIC_AUTHUP_URL=https://${HOST}/auth/
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dnpm-frontend.rule=PathPrefix(`/`)"
+      - "traefik.http.services.dnpm-frontend.loadbalancer.server.port=3000"
+      - "traefik.http.routers.dnpm-frontend.tls=true"
+
+  dnpm-backend:
+    container_name: bridgehead-dnpm-backend
+    image: ghcr.io/kohlbacherlab/dnpm-dip-backend:latest
+    environment:
+      - LOCAL_SITE=${ZPM_SITE}:${SITE_ID}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
+      - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
+      - MTB_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
+      - HATEOAS_HOST=https://${HOST}
+      - CONNECTOR_TYPE=${BACKEND_CONNECTOR_TYPE:-broker}
+      - AUTHUP_URL=robot://system:${DNPM_AUTHUP_SECRET}@http://dnpm-authup:3000
+    volumes:
+      - /etc/bridgehead/dnpm/config:/dnpm_config
+      - dnpm-backend-data:/dnpm_data
+    depends_on:
+      dnpm-authup:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dnpm-backend.rule=PathPrefix(`/api`)"
+      - "traefik.http.services.dnpm-backend.loadbalancer.server.port=9000"
+      - "traefik.http.routers.dnpm-backend.tls=true"
+
+  landing:
+    labels:
+      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"
+
+volumes:
+  dnpm-authup:
+  dnpm-mysql:
+  dnpm-backend-data:

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   dnpm-mysql:
-    image: mysql:latest
+    image: mysql:9
     healthcheck:
       test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
       interval: 3s

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -43,7 +43,7 @@ services:
       - "traefik.http.routers.dnpm-auth.tls=true"
 
   dnpm-portal:
-    image: ghcr.io/kohlbacherlab/dnpm-dip-portal:latest
+    image: ghcr.io/dnpm-dip/portal:latest
     container_name: bridgehead-dnpm-portal
     environment:
       - NUXT_API_URL=http://dnpm-backend:9000/
@@ -58,7 +58,7 @@ services:
 
   dnpm-backend:
     container_name: bridgehead-dnpm-backend
-    image: ghcr.io/kohlbacherlab/dnpm-dip-backend:latest
+    image: ghcr.io/dnpm-dip/backend:latest
     environment:
       - LOCAL_SITE=${ZPM_SITE}:${SITE_NAME}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
       - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -60,7 +60,7 @@ services:
     container_name: bridgehead-dnpm-backend
     image: ghcr.io/kohlbacherlab/dnpm-dip-backend:latest
     environment:
-      - LOCAL_SITE=${ZPM_SITE}:${SITE_ID}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
+      - LOCAL_SITE=${ZPM_SITE}:${SITE_NAME}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
       - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
       - MTB_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}
       - HATEOAS_HOST=https://${HOST}

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -74,9 +74,25 @@ services:
         condition: service_healthy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.dnpm-backend.rule=PathPrefix(`/api`)"
       - "traefik.http.services.dnpm-backend.loadbalancer.server.port=9000"
+      # expose everything
+      - "traefik.http.routers.dnpm-backend.rule=PathPrefix(`/api`)"
       - "traefik.http.routers.dnpm-backend.tls=true"
+      - "traefik.http.routers.dnpm-backend.service=dnpm-backend"
+      # except ETL
+      - "traefik.http.routers.dnpm-backend-etl.rule=PathRegexp(`^/api(/.*)?etl(/.*)?$`)"
+      - "traefik.http.routers.dnpm-backend-etl.tls=true"
+      - "traefik.http.routers.dnpm-backend-etl.service=dnpm-backend"
+      # this needs an ETL processor with support for basic auth
+      - "traefik.http.routers.dnpm-backend-etl.middlewares=auth"
+      # except peer-to-peer
+      - "traefik.http.routers.dnpm-backend-peer.rule=PathRegexp(`^/api(/.*)?/peer2peer(/.*)?$`)"
+      - "traefik.http.routers.dnpm-backend-peer.tls=true"
+      - "traefik.http.routers.dnpm-backend-peer.service=dnpm-backend"
+      - "traefik.http.routers.dnpm-backend-peer.middlewares=dnpm-backend-peer"
+      # this effectively denies all requests
+      # this is okay, because requests from peers don't go through Traefik
+      - "traefik.http.middlewares.dnpm-backend-peer.ipWhiteList.sourceRange=0.0.0.0/32"
 
   landing:
     labels:

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -12,13 +12,13 @@ services:
       MYSQL_ROOT_HOST: "%"
       MYSQL_ROOT_PASSWORD: ${DNPM_MYSQL_ROOT_PASSWORD}
     volumes:
-      - dnpm-mysql:/var/lib/mysql
+      - /var/cache/bridgehead/dnpm/mysql:/var/lib/mysql
 
   dnpm-authup:
     image: authup/authup:latest
     container_name: bridgehead-dnpm-authup
     volumes:
-      - dnpm-authup:/usr/src/app/writable
+      - /var/cache/bridgehead/dnpm/authup:/usr/src/app/writable
     depends_on:
       dnpm-mysql:
         condition: service_healthy
@@ -68,7 +68,7 @@ services:
       - AUTHUP_URL=robot://system:${DNPM_AUTHUP_SECRET}@http://dnpm-authup:3000
     volumes:
       - /etc/bridgehead/dnpm/config:/dnpm_config
-      - dnpm-backend-data:/dnpm_data
+      - /var/cache/bridgehead/dnpm/backend-data:/dnpm_data
     depends_on:
       dnpm-authup:
         condition: service_healthy
@@ -81,8 +81,3 @@ services:
   landing:
     labels:
       - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"
-
-volumes:
-  dnpm-authup:
-  dnpm-mysql:
-  dnpm-backend-data:

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -36,7 +36,7 @@ services:
       - DB_DATABASE=auth
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.authup-strip.stripprefix.prefixes=/auth"
+      - "traefik.http.middlewares.authup-strip.stripprefix.prefixes=/auth/"
       - "traefik.http.routers.dnpm-auth.middlewares=authup-strip"
       - "traefik.http.routers.dnpm-auth.rule=PathPrefix(`/auth`)"
       - "traefik.http.services.dnpm-auth.loadbalancer.server.port=3000"

--- a/minimal/modules/dnpm-node-setup.sh
+++ b/minimal/modules/dnpm-node-setup.sh
@@ -10,7 +10,7 @@ if [ -n "${ENABLE_DNPM_NODE}" ]; then
 		exit 1
 	fi
     mkdir -p /var/cache/bridgehead/dnpm/ || fail_and_report 1 "Failed to create '/var/cache/bridgehead/dnpm/'. Please run sudo './bridgehead install $PROJECT' again to fix the permissions."
-	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:--1}
+    DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:--1}
     DNPM_MYSQL_ROOT_PASSWORD="$(generate_simple_password 'dnpm mysql')"
     DNPM_AUTHUP_SECRET="$(generate_simple_password 'dnpm authup')"
 fi

--- a/minimal/modules/dnpm-node-setup.sh
+++ b/minimal/modules/dnpm-node-setup.sh
@@ -1,28 +1,15 @@
 #!/bin/bash
 
 if [ -n "${ENABLE_DNPM_NODE}" ]; then
-	log INFO "DNPM setup detected (BwHC Node) -- will start BwHC node."
+	log INFO "DNPM setup detected -- will start DNPM:DIP node."
 	OVERRIDE+=" -f ./$PROJECT/modules/dnpm-node-compose.yml"
 
 	# Set variables required for BwHC Node. ZPM_SITE is assumed to be set in /etc/bridgehead/<project>.conf
-	DNPM_APPLICATION_SECRET="$(echo \"This is a salt string to generate one consistent password for DNPM. It is not required to be secret.\" | sha1sum | openssl pkeyutl -sign -inkey /etc/bridgehead/pki/${SITE_ID}.priv.pem | base64 | head -c 30)"
 	if [ -z "${ZPM_SITE+x}" ]; then
 		log ERROR "Mandatory variable ZPM_SITE not defined!"
 		exit 1
 	fi
-	if [ -z "${DNPM_DATA_DIR+x}" ]; then
-		log ERROR "Mandatory variable DNPM_DATA_DIR not defined!"
-		exit 1
-	fi
-	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:-0}
-	if grep -q 'traefik.http.routers.landing.rule=PathPrefix(`/landing`)' /srv/docker/bridgehead/minimal/docker-compose.override.yml 2>/dev/null; then
-		echo "Override of landing page url already in place"
-	else
-		echo "Adding override of landing page url"
-		if [ -f /srv/docker/bridgehead/minimal/docker-compose.override.yml ]; then
-			echo -e '  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
-		else
-			echo -e 'version: "3.7"\nservices:\n  landing:\n    labels:\n      - "traefik.http.routers.landing.rule=PathPrefix(`/landing`)"' >> /srv/docker/bridgehead/minimal/docker-compose.override.yml
-		fi
-	fi
+	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:--1}
+    DNPM_MYSQL_ROOT_PASSWORD="$(generate_simple_password 'dnpm mysql')"
+    DNPM_AUTHUP_SECRET="$(generate_simple_password 'dnpm authup')"
 fi

--- a/minimal/modules/dnpm-node-setup.sh
+++ b/minimal/modules/dnpm-node-setup.sh
@@ -9,6 +9,7 @@ if [ -n "${ENABLE_DNPM_NODE}" ]; then
 		log ERROR "Mandatory variable ZPM_SITE not defined!"
 		exit 1
 	fi
+    mkdir -p /var/cache/bridgehead/dnpm/ || fail_and_report 1 "Failed to create '/var/cache/bridgehead/dnpm/'. Please run sudo './bridgehead install $PROJECT' again to fix the permissions."
 	DNPM_SYNTH_NUM=${DNPM_SYNTH_NUM:--1}
     DNPM_MYSQL_ROOT_PASSWORD="$(generate_simple_password 'dnpm mysql')"
     DNPM_AUTHUP_SECRET="$(generate_simple_password 'dnpm authup')"


### PR DESCRIPTION
The files under `ccp/` are only copies of the files under `minimal/`.

I removed the `/api` path from traefik as it was conflicting with dnpms backend path.
I have never seen anyone of us actually use the traefik frontend but I think `/dashboard` is a better name anyway but if we want to keep it that way we might be able to do a bit of traefik path rewriting to make it work without this change.

Maybe we can even backport this to the `dnpm-extra-broker` branch?