### PR TITLE
fix: changed ccp_ppi to use IDMANAGEMENT_FRIENDLY_ID instead of SITE_NAME

### DIFF
--- a/ccp/modules/id-management-compose.yml
+++ b/ccp/modules/id-management-compose.yml
@@ -106,7 +106,7 @@ services:
     container_name: bridgehead-ccp-patient-project-identificator
     environment:
       MAINZELLISTE_APIKEY: ${IDMANAGER_LOCAL_PATIENTLIST_APIKEY}
-      SITE_NAME: ${SITE_NAME}
+      SITE_NAME: ${IDMANAGEMENT_FRIENDLY_ID}
 
 volumes:
   patientlist-db-data:


### PR DESCRIPTION
This PR fixes the environment variable of the CCP-PPI, where the SITE_NAME is not consistent with the IDMANAGEMENT_FRIENDLY_ID