### PR TITLE
fix: remove `restart: always` in compose files

### DIFF
--- a/ccp/modules/nngm-compose.yml
+++ b/ccp/modules/nngm-compose.yml
@@ -12,7 +12,6 @@ services:
       CTS_API_KEY: ${NNGM_CTS_APIKEY}
       CRYPT_KEY: ${NNGM_CRYPTKEY}
       #CTS_MAGICPL_SITE: ${SITE_ID}TODO
-    restart: always
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.connector.rule=PathPrefix(`/nngm-connector`)"

--- a/ccp/modules/obds2fhir-rest-compose.yml
+++ b/ccp/modules/obds2fhir-rest-compose.yml
@@ -10,7 +10,6 @@ services:
       SALT: ${LOCAL_SALT}
       KEEP_INTERNAL_ID: ${KEEP_INTERNAL_ID:-false}
       MAINZELLISTE_URL: ${PATIENTLIST_URL:-http://patientlist:8080/patientlist}
-    restart: always
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.obds2fhir-rest.rule=PathPrefix(`/obds2fhir-rest`) || PathPrefix(`/adt2fhir-rest`)"

--- a/kr/modules/obds2fhir-rest-compose.yml
+++ b/kr/modules/obds2fhir-rest-compose.yml
@@ -10,7 +10,6 @@ services:
       SALT: ${LOCAL_SALT}
       KEEP_INTERNAL_ID: ${KEEP_INTERNAL_ID:-false}
       MAINZELLISTE_URL: ${PATIENTLIST_URL:-http://patientlist:8080/patientlist}
-    restart: always
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.obds2fhir-rest.rule=PathPrefix(`/obds2fhir-rest`) || PathPrefix(`/adt2fhir-rest`)"

--- a/minimal/modules/nngm-compose.yml
+++ b/minimal/modules/nngm-compose.yml
@@ -11,7 +11,6 @@ services:
       CTS_API_KEY: ${NNGM_CTS_APIKEY}
       CRYPT_KEY: ${NNGM_CRYPTKEY}
       #CTS_MAGICPL_SITE: ${SITE_ID}TODO
-    restart: always
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.connector.rule=PathPrefix(`/nngm-connector`)"


### PR DESCRIPTION
I dont know if there is a good reason for it for the secondary blaze @PierreDelpy