### PR TITLE
fix authup redirect

### DIFF
--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -36,7 +36,7 @@ services:
       - DB_DATABASE=auth
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.authup-strip.stripprefix.prefixes=/auth"
+      - "traefik.http.middlewares.authup-strip.stripprefix.prefixes=/auth/"
       - "traefik.http.routers.dnpm-auth.middlewares=authup-strip"
       - "traefik.http.routers.dnpm-auth.rule=PathPrefix(`/auth`)"
       - "traefik.http.services.dnpm-auth.loadbalancer.server.port=3000"


### PR DESCRIPTION
When a OIDC provider is configured, you'll get redirected to authup by Keycloak which redirects you to the DNPM:DIP. 

Currently the url looks like this:
`https://myserver/authup//someurl`
 and produces an error. Manually removing the additional `/` fixes the issue.