### PR TITLE
Fixed Docker Hub URL list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following URLs need to be accessible (prefix with `https://`):
   * git.verbis.dkfz.de
 * To fetch docker images
   * docker.verbis.dkfz.de
-  * Official Docker, Inc. URLs (subject to change, see [official list](https://docs.docker.com/desktop/all))
+  * Official Docker, Inc. URLs (subject to change, see [official list](https://docs.docker.com/desktop/setup/allow-list/))
     * hub.docker.com
     * registry-1.docker.io
     * production.cloudflare.docker.com


### PR DESCRIPTION
As described in #263, the link to the official Docker Hub URL list changed, leading to a 404 error  with the current readme. This PR links to the new site. 