### PR TITLE
fix: properly load oidc secrets

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -318,7 +318,7 @@ function sync_secrets() {
         docker.verbis.dkfz.de/cache/samply/secret-sync-local:latest
 
     set -a # Export variables as environment variables
-    source /var/cache/bridgehead/secrets/*
+    source /var/cache/bridgehead/secrets/oidc
     set +a # Export variables in the regular way
 }
 


### PR DESCRIPTION
fixes serv-05

Really don't know why this only sourced the first file.
I guess it was a CentOS specialty.