### PR TITLE
docs: explicitly clone main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Pay special attention to:
 Clone the bridgehead repository:
 ```shell
 sudo mkdir -p /srv/docker/
-sudo git clone https://github.com/samply/bridgehead.git /srv/docker/bridgehead
+sudo git clone -b main https://github.com/samply/bridgehead.git /srv/docker/bridgehead
 ```
 
 Then, run the installation script:


### PR DESCRIPTION
With the recent change of the default branch to develop, new bridgehead installations will default upon cloning to the develop branch. With adjusting the instructions like this, git will clone the main branch.