### PR TITLE
chore: unify blaze versioning and upgrade to 0.32

### DIFF
--- a/bbmri/docker-compose.yml
+++ b/bbmri/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.7"
 
 services:
   blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.31
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-bbmri-blaze
     environment:
       BASE_URL: "http://bridgehead-bbmri-blaze:8080"

--- a/cce/docker-compose.yml
+++ b/cce/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.31
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-cce-blaze
     environment:
       BASE_URL: "http://bridgehead-cce-blaze:8080"

--- a/ccp/docker-compose.yml
+++ b/ccp/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.31
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-ccp-blaze
     environment:
       BASE_URL: "http://bridgehead-ccp-blaze:8080"

--- a/ccp/modules/blaze-secondary-compose.yml
+++ b/ccp/modules/blaze-secondary-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   blaze-secondary:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.31
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-ccp-blaze-secondary
     environment:
       BASE_URL: "http://bridgehead-ccp-blaze-secondary:8080"

--- a/dhki/docker-compose.yml
+++ b/dhki/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.31
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-dhki-blaze
     environment:
       BASE_URL: "http://bridgehead-dhki-blaze:8080"

--- a/itcc/docker-compose.yml
+++ b/itcc/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.31
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-itcc-blaze
     environment:
       BASE_URL: "http://bridgehead-itcc-blaze:8080"

--- a/kr/docker-compose.yml
+++ b/kr/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       replicas: 0 #deactivate landing page
 
   blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.31
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-kr-blaze
     environment:
       BASE_URL: "http://bridgehead-kr-blaze:8080"

--- a/modules/transfair-compose.yml
+++ b/modules/transfair-compose.yml
@@ -21,7 +21,7 @@ services:
       - /var/cache/bridgehead/${PROJECT}/transfair:/transfair
 
   transfair-input-blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.28
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-transfair-input-blaze
     environment:
       BASE_URL: "http://bridgehead-transfair-input-blaze:8080"
@@ -34,7 +34,7 @@ services:
     profiles: ["transfair-input-blaze"]
 
   transfair-request-blaze:
-    image: docker.verbis.dkfz.de/cache/samply/blaze:0.28
+    image: docker.verbis.dkfz.de/cache/samply/blaze:${BLAZE_TAG}
     container_name: bridgehead-transfair-requests-blaze
     environment:
       BASE_URL: "http://bridgehead-transfair-requests-blaze:8080"

--- a/versions/prod
+++ b/versions/prod
@@ -1,2 +1,3 @@
 FOCUS_TAG=main
 BEAM_TAG=main
+BLAZE_TAG=0.32

--- a/versions/test
+++ b/versions/test
@@ -1,2 +1,3 @@
 FOCUS_TAG=develop
 BEAM_TAG=develop
+BLAZE_TAG=main


### PR DESCRIPTION
Seems like there are no breaking changes https://github.com/samply/blaze/releases/tag/v0.32.0