### PR TITLE
Use tmp directory for secret sync cache

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -348,7 +348,7 @@ function secret_sync_gitlab_token() {
     fi
 
     # Create a temporary directory for Secret Sync that is valid per boot
-    secret_sync_tempdir="/tmp/secret-sync.boot-$(cat /proc/sys/kernel/random/boot_id)"
+    secret_sync_tempdir="/tmp/bridgehead/secret-sync.boot-$(cat /proc/sys/kernel/random/boot_id)"
     mkdir -p $secret_sync_tempdir
 
     # Use Secret Sync to validate the GitLab token in $secret_sync_tempdir/cache.

--- a/lib/gitlab-token-helper.sh
+++ b/lib/gitlab-token-helper.sh
@@ -2,7 +2,7 @@
 
 [ "$1" = "get" ] || exit
 
-source /var/cache/bridgehead/secrets/gitlab_token
+source "/tmp/secret-sync.boot-$(cat /proc/sys/kernel/random/boot_id)/gitlab-token"
 
 # Any non-empty username works, only the token matters
 cat << EOF

--- a/lib/gitlab-token-helper.sh
+++ b/lib/gitlab-token-helper.sh
@@ -2,7 +2,7 @@
 
 [ "$1" = "get" ] || exit
 
-source "/tmp/secret-sync.boot-$(cat /proc/sys/kernel/random/boot_id)/gitlab-token"
+source "/tmp/bridgehead/secret-sync.boot-$(cat /proc/sys/kernel/random/boot_id)/gitlab-token"
 
 # Any non-empty username works, only the token matters
 cat << EOF


### PR DESCRIPTION
`/var/cache/bridgehead` did not exist on some bridgeheads, probably because they were installed before https://github.com/samply/bridgehead/blob/7365be3e7bf4d6ab7a9dcc4d5de40c8a13e5a8dc/lib/prepare-system.sh#L107 was added.

This PR uses a boot-scoped temporary directory to avoid such issues in the future.

The previous implementation kind of caused a mess on some servers because the Docker daemon created `/var/cache/bridgehead/secrets/gitlab_token` as a directory with owner `root:root`. Would be kind of difficult to clean up as most scripts run as `bridgehead` user.