### PR TITLE
[Hotfix] Teiler without Internet

### DIFF
--- a/ccp/modules/teiler-compose.yml
+++ b/ccp/modules/teiler-compose.yml
@@ -31,6 +31,7 @@ services:
     environment:
       DEFAULT_LANGUAGE: "${TEILER_DEFAULT_LANGUAGE}"
       TEILER_BACKEND_URL: "https://${HOST}/ccp-teiler-backend"
+      TEILER_DASHBOARD_URL: "https://${HOST}/ccp-teiler-dashboard"
       OIDC_URL: "${OIDC_URL}"
       OIDC_REALM: "${OIDC_REALM}"
       OIDC_CLIENT_ID: "${OIDC_PUBLIC_CLIENT_ID}"
@@ -41,7 +42,6 @@ services:
       TEILER_PROJECT: "${PROJECT}"
       EXPORTER_API_KEY: "${EXPORTER_API_KEY}"
       TEILER_ORCHESTRATOR_URL: "https://${HOST}/ccp-teiler"
-      TEILER_DASHBOARD_HTTP_RELATIVE_PATH: "/ccp-teiler-dashboard"
       TEILER_ORCHESTRATOR_HTTP_RELATIVE_PATH: "/ccp-teiler"
       TEILER_USER: "${OIDC_USER_GROUP}"
       TEILER_ADMIN: "${OIDC_ADMIN_GROUP}"


### PR DESCRIPTION
**Summary:**
This pull request introduces a small configuration update for Teiler to support the new Docker images. These new images embed external libraries, allowing Teiler to run without requiring internet access.

**Compatibility:**
The change is fully backward compatible with previous versions of the old Teiler Docker images, so merging into main should not cause any issues.