### PR TITLE
Update some Teiler Backend variables

### DIFF
--- a/ccp/modules/teiler-compose.yml
+++ b/ccp/modules/teiler-compose.yml
@@ -69,10 +69,10 @@ services:
       TEILER_ORCHESTRATOR_URL: "https://${HOST}/ccp-teiler"
       TEILER_DASHBOARD_DE_URL: "https://${HOST}/ccp-teiler-dashboard/de"
       TEILER_DASHBOARD_EN_URL: "https://${HOST}/ccp-teiler-dashboard/en"
-      CENTRAX_URL: "${CENTRAXX_URL}"
       HTTP_PROXY: "http://forward_proxy:3128"
       ENABLE_MTBA: "${ENABLE_MTBA}"
       ENABLE_DATASHIELD: "${ENABLE_DATASHIELD}"
+      IDMANAGER_UPLOAD_APIKEY: "${IDMANAGER_UPLOAD_APIKEY}" # Only used to check if the ID Manager is active
     secrets:
       - ccp.conf
 

--- a/kr/modules/teiler-compose.yml
+++ b/kr/modules/teiler-compose.yml
@@ -31,6 +31,7 @@ services:
     environment:
       DEFAULT_LANGUAGE: "${TEILER_DEFAULT_LANGUAGE}"
       TEILER_BACKEND_URL: "https://${HOST}/ccp-teiler-backend"
+      TEILER_DASHBOARD_URL: "https://${HOST}/ccp-teiler-dashboard"
       OIDC_URL: "${OIDC_URL}"
       OIDC_REALM: "${OIDC_REALM}"
       OIDC_CLIENT_ID: "${OIDC_PUBLIC_CLIENT_ID}"
@@ -41,7 +42,6 @@ services:
       TEILER_PROJECT: "${PROJECT}"
       EXPORTER_API_KEY: "${EXPORTER_API_KEY}"
       TEILER_ORCHESTRATOR_URL: "https://${HOST}/ccp-teiler"
-      TEILER_DASHBOARD_HTTP_RELATIVE_PATH: "/ccp-teiler-dashboard"
       TEILER_ORCHESTRATOR_HTTP_RELATIVE_PATH: "/ccp-teiler"
       TEILER_USER: "${OIDC_USER_GROUP}"
       TEILER_ADMIN: "${OIDC_ADMIN_GROUP}"
@@ -69,7 +69,6 @@ services:
       TEILER_ORCHESTRATOR_URL: "https://${HOST}/ccp-teiler"
       TEILER_DASHBOARD_DE_URL: "https://${HOST}/ccp-teiler-dashboard/de"
       TEILER_DASHBOARD_EN_URL: "https://${HOST}/ccp-teiler-dashboard/en"
-      CENTRAX_URL: "${CENTRAXX_URL}"
       HTTP_PROXY: "http://forward_proxy:3128"
       ENABLE_MTBA: "${ENABLE_MTBA}"
       ENABLE_DATASHIELD: "${ENABLE_DATASHIELD}"


### PR DESCRIPTION
Small configuration update for the latest version of the Teiler Backend.
The changes are backward compatible and apply to both CCP and KR.