### PR TITLE
Externalize POSTGRES_TAG. Bump postgres to 15.13

### DIFF
--- a/ccp/vars
+++ b/ccp/vars
@@ -18,8 +18,6 @@ OIDC_URL="https://login.verbis.dkfz.de"
 OIDC_ISSUER_URL="${OIDC_URL}/realms/${OIDC_REALM}"
 OIDC_GROUP_CLAIM="groups"
 
-POSTGRES_TAG=15.6-alpine
-
 for module in $PROJECT/modules/*.sh
 do
     log DEBUG "sourcing $module"

--- a/dhki/vars
+++ b/dhki/vars
@@ -8,8 +8,6 @@ PRIVATEKEYFILENAME=/etc/bridgehead/pki/${SITE_ID}.priv.pem
 
 BROKER_URL_FOR_PREREQ=$BROKER_URL
 
-POSTGRES_TAG=15.6-alpine
-
 for module in ccp/modules/*.sh
 do
     log DEBUG "sourcing $module"

--- a/versions/acceptance
+++ b/versions/acceptance
@@ -1,3 +1,4 @@
 FOCUS_TAG=develop
 BEAM_TAG=develop
 BLAZE_TAG=main
+POSTGRES_TAG=15.13-alpine

--- a/versions/prod
+++ b/versions/prod
@@ -1,3 +1,4 @@
 FOCUS_TAG=main
 BEAM_TAG=main
 BLAZE_TAG=0.32
+POSTGRES_TAG=15.13-alpine

--- a/versions/test
+++ b/versions/test
@@ -1,3 +1,4 @@
 FOCUS_TAG=develop
 BEAM_TAG=develop
 BLAZE_TAG=main
+POSTGRES_TAG=15.13-alpine


### PR DESCRIPTION
* Externalizes `POSTGRES_TAG` into test/acceptance/prod environment
* Bump postgres version to 15.13