### PR TITLE
feat(dnpm): change to new `api-gateway` image

### DIFF
--- a/ccp/modules/dnpm-node-compose.yml
+++ b/ccp/modules/dnpm-node-compose.yml
@@ -58,7 +58,7 @@ services:
 
   dnpm-backend:
     container_name: bridgehead-dnpm-backend
-    image: ghcr.io/dnpm-dip/backend:${DNPM_IMAGE_TAG:-latest}
+    image: ghcr.io/dnpm-dip/api-gateway:latest
     environment:
       - LOCAL_SITE=${ZPM_SITE}:${SITE_NAME}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
       - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}

--- a/minimal/modules/dnpm-node-compose.yml
+++ b/minimal/modules/dnpm-node-compose.yml
@@ -58,7 +58,7 @@ services:
 
   dnpm-backend:
     container_name: bridgehead-dnpm-backend
-    image: ghcr.io/dnpm-dip/backend:${DNPM_IMAGE_TAG:-latest}
+    image: ghcr.io/dnpm-dip/api-gateway:latest
     environment:
       - LOCAL_SITE=${ZPM_SITE}:${SITE_NAME}   # Format: {Site-ID}:{Site-name}, e.g. UKT:Tübingen
       - RD_RANDOM_DATA=${DNPM_SYNTH_NUM:--1}


### PR DESCRIPTION
I removed the tag option for now as it does not have any other tags and I don't want to break deployments that use a custom tag