### PR TITLE
use latest blaze in test

### DIFF
--- a/versions/test
+++ b/versions/test
@@ -1,6 +1,6 @@
 FOCUS_TAG=develop
 BEAM_TAG=develop
-BLAZE_TAG=0.32
+BLAZE_TAG=latest
 POSTGRES_TAG=15.13-alpine
 TEILER_DASHBOARD_TAG=develop
 MTBA_TAG=develop


### PR DESCRIPTION
focus:develop doesn't use the function with 2 different resources anymore, so it should work with blaze:latest