### PR TITLE
Fix spelling of 'Charite' to 'Charité' in DNPM targets

### DIFF
--- a/minimal/modules/dnpm-central-targets.json
+++ b/minimal/modules/dnpm-central-targets.json
@@ -49,7 +49,7 @@
             "beamconnect": "dnpm-connect.dnpm-bridge.broker.ccp-it.dktk.dkfz.de"
         },
         {
-            "id": "Charite",
+            "id": "Charité",
             "name": "Berlin",
             "virtualhost": "charite.dnpm.de",
             "beamconnect": "dnpm-connect.berlin-test.broker.ccp-it.dktk.dkfz.de"


### PR DESCRIPTION
The spelling inconsistency causes the DNPM node to not access itself properly