### PR TITLE
added CQL_FLAVOUR

### DIFF
--- a/bbmri/modules/eric-compose.yml
+++ b/bbmri/modules/eric-compose.yml
@@ -12,6 +12,7 @@ services:
       BEAM_PROXY_URL: http://beam-proxy-eric:8081
       RETRY_COUNT: ${FOCUS_RETRY_COUNT}
       OBFUSCATE_BBMRI_ERIC_WAY: "true"
+      CQL_FLAVOUR: "${CQL_FLAVOUR}"
     depends_on:
       - "beam-proxy-eric"
       - "blaze"

--- a/bbmri/modules/eric-compose.yml
+++ b/bbmri/modules/eric-compose.yml
@@ -12,7 +12,7 @@ services:
       BEAM_PROXY_URL: http://beam-proxy-eric:8081
       RETRY_COUNT: ${FOCUS_RETRY_COUNT}
       OBFUSCATE_BBMRI_ERIC_WAY: "true"
-      CQL_FLAVOUR: "${CQL_FLAVOUR}"
+      CQL_FLAVOUR: "${FOCUS_CQL_FLAVOUR}"
     depends_on:
       - "beam-proxy-eric"
       - "blaze"


### PR DESCRIPTION
variable that tells Focus which CQL "flavour" to use when translating AST to CQL
when not set (in most circumstances) Focus uses the project name from the task metadata